### PR TITLE
Enforce single trustPurpose for End entity certificates

### DIFF
--- a/lib/cert.py
+++ b/lib/cert.py
@@ -158,7 +158,7 @@ def handle_extensions(builder, ext, enrollment, subject_keys, ca_keys):
         dns_names = [x509.DNSName(name) for name in enrollment['subjectAltNames']]
         builder = builder.add_extension(
             x509.SubjectAlternativeName(dns_names),
-            critical=ext['subjectAltNames'].get('critical', False)
+            critical=ext.get('subjectAltNames', {}).get('critical', False)
         )
 
     return builder

--- a/profiles/G4TRIALEEPrivGOtherLP2025.yaml
+++ b/profiles/G4TRIALEEPrivGOtherLP2025.yaml
@@ -26,20 +26,14 @@ extensions:
       oid: 0.4.0.2042.1.1
     - name: ncpplus
       oid: 0.4.0.2042.1.2
-    - name: id-pkio-cp-g4d-gen10PrvOth-lpOrg-authy
-      oid: 2.16.528.1.1003.1.2.41.16.25.4
     - name: id-pkio-cp-g4d-gen10PrvOth-lpOrg-authon
       oid: 2.16.528.1.1003.1.2.41.16.25.8
   extendedKeyUsage:
     critical: false
     oid: 2.5.29.37
     value:
-    - name: szOID_KP_DOCUMENT_SIGNING
-      oid: 1.3.6.1.4.1.311.10.3.12
     - name: id-kp-clientAuth
       oid: 1.3.6.1.5.5.7.3.2
-    - name: id-kp-documentSigning
-      oid: 1.3.6.1.5.5.7.3.36
   keyUsage:
     critical: true
     oid: 2.5.29.15
@@ -91,10 +85,12 @@ validations:
           type: string
         organizationIdentifier:
           maxLength: 64
+          minLength: 2
           pattern: NTRNL-[0-9]{8}
           type: string
         serialNumber:
           maxLength: 64
+          minLength: 2
           type: string
       required:
       - C

--- a/profiles/G4TRIALEEPrivGOtherNP2025IndividualValidated.yaml
+++ b/profiles/G4TRIALEEPrivGOtherNP2025IndividualValidated.yaml
@@ -26,20 +26,14 @@ extensions:
       oid: 0.4.0.2042.1.1
     - name: ncpplus
       oid: 0.4.0.2042.1.2
-    - name: id-pkio-cp-g4d-gen10PrvOth-npInd-authy
-      oid: 2.16.528.1.1003.1.2.41.16.11.4
     - name: id-pkio-cp-g4d-gen10PrvOth-npInd-authon
       oid: 2.16.528.1.1003.1.2.41.16.11.8
   extendedKeyUsage:
     critical: false
     oid: 2.5.29.37
     value:
-    - name: szOID_KP_DOCUMENT_SIGNING
-      oid: 1.3.6.1.4.1.311.10.3.12
     - name: id-kp-clientAuth
       oid: 1.3.6.1.5.5.7.3.2
-    - name: id-kp-documentSigning
-      oid: 1.3.6.1.5.5.7.3.36
   keyUsage:
     critical: true
     oid: 2.5.29.15
@@ -88,6 +82,7 @@ validations:
           type: string
         serialNumber:
           maxLength: 64
+          minLength: 2
           type: string
       required:
       - C

--- a/profiles/G4TRIALEEPrivGOtherNP2025RegulatedProfession.yaml
+++ b/profiles/G4TRIALEEPrivGOtherNP2025RegulatedProfession.yaml
@@ -26,20 +26,14 @@ extensions:
       oid: 0.4.0.2042.1.1
     - name: ncpplus
       oid: 0.4.0.2042.1.2
-    - name: id-pkio-cp-g4d-gen10PrvOth-npRegP-authy
-      oid: 2.16.528.1.1003.1.2.41.16.12.4
     - name: id-pkio-cp-g4d-gen10PrvOth-npRegP-authon
       oid: 2.16.528.1.1003.1.2.41.16.12.8
   extendedKeyUsage:
     critical: false
     oid: 2.5.29.37
     value:
-    - name: szOID_KP_DOCUMENT_SIGNING
-      oid: 1.3.6.1.4.1.311.10.3.12
     - name: id-kp-clientAuth
       oid: 1.3.6.1.5.5.7.3.2
-    - name: id-kp-documentSigning
-      oid: 1.3.6.1.5.5.7.3.36
   keyUsage:
     critical: true
     oid: 2.5.29.15
@@ -88,9 +82,11 @@ validations:
           type: string
         serialNumber:
           maxLength: 64
+          minLength: 2
           type: string
         title:
           maxLength: 64
+          minLength: 2
           type: string
       required:
       - C

--- a/profiles/G4TRIALEEPrivGOtherNP2025RegulatedProfessionwithSponsorValidation.yaml
+++ b/profiles/G4TRIALEEPrivGOtherNP2025RegulatedProfessionwithSponsorValidation.yaml
@@ -26,20 +26,14 @@ extensions:
       oid: 0.4.0.2042.1.1
     - name: ncpplus
       oid: 0.4.0.2042.1.2
-    - name: id-pkio-cp-g4d-gen10PrvOth-npRPSp-authy
-      oid: 2.16.528.1.1003.1.2.41.16.14.4
     - name: id-pkio-cp-g4d-gen10PrvOth-npRPSp-authon
       oid: 2.16.528.1.1003.1.2.41.16.14.8
   extendedKeyUsage:
     critical: false
     oid: 2.5.29.37
     value:
-    - name: szOID_KP_DOCUMENT_SIGNING
-      oid: 1.3.6.1.4.1.311.10.3.12
     - name: id-kp-clientAuth
       oid: 1.3.6.1.5.5.7.3.2
-    - name: id-kp-documentSigning
-      oid: 1.3.6.1.5.5.7.3.36
   keyUsage:
     critical: true
     oid: 2.5.29.15
@@ -102,9 +96,11 @@ validations:
           type: string
         serialNumber:
           maxLength: 64
+          minLength: 2
           type: string
         title:
           maxLength: 64
+          minLength: 2
           type: string
       required:
       - C

--- a/profiles/G4TRIALEEPrivGOtherNP2025SponsorValidated.yaml
+++ b/profiles/G4TRIALEEPrivGOtherNP2025SponsorValidated.yaml
@@ -26,20 +26,14 @@ extensions:
       oid: 0.4.0.2042.1.1
     - name: ncpplus
       oid: 0.4.0.2042.1.2
-    - name: id-pkio-cp-g4d-gen10PrvOth-npSpon-authy
-      oid: 2.16.528.1.1003.1.2.41.16.13.4
     - name: id-pkio-cp-g4d-gen10PrvOth-npSpon-authon
       oid: 2.16.528.1.1003.1.2.41.16.13.8
   extendedKeyUsage:
     critical: false
     oid: 2.5.29.37
     value:
-    - name: szOID_KP_DOCUMENT_SIGNING
-      oid: 1.3.6.1.4.1.311.10.3.12
     - name: id-kp-clientAuth
       oid: 1.3.6.1.5.5.7.3.2
-    - name: id-kp-documentSigning
-      oid: 1.3.6.1.5.5.7.3.36
   keyUsage:
     critical: true
     oid: 2.5.29.15
@@ -91,6 +85,7 @@ validations:
           type: string
         O:
           maxLength: 64
+          minLength: 2
           type: string
         SN:
           maxLength: 64
@@ -101,6 +96,7 @@ validations:
           type: string
         serialNumber:
           maxLength: 64
+          minLength: 2
           type: string
       required:
       - C

--- a/profiles/G4TRIALEEPrivGTLSSYS2025.yaml
+++ b/profiles/G4TRIALEEPrivGTLSSYS2025.yaml
@@ -84,6 +84,7 @@ validations:
           type: string
         CN:
           maxLength: 64
+          minLength: 2
           type: string
         O:
           maxLength: 64
@@ -94,6 +95,7 @@ validations:
           type: string
         serialNumber:
           maxLength: 64
+          minLength: 2
           type: string
       required:
       - C

--- a/profiles/G4TRIALEEPrivGTLSSYS2025.yaml
+++ b/profiles/G4TRIALEEPrivGTLSSYS2025.yaml
@@ -47,12 +47,6 @@ extensions:
       name: id-qcs-pkixQCSyntax-v2
       oid: 1.3.6.1.5.5.7.11.2
       value: 0.4.0.194121.1.2 (id-etsi-qcs-SemanticsId-Legal)
-  subjectAltNames:
-    critical: false
-    oid: 2.5.29.17
-    value:
-    - example.com
-    - www.example.com
   subjectKeyIdentifier:
     critical: false
     oid: 2.5.29.14


### PR DESCRIPTION
This PR:
* Removes `authy` (Authenticity) from end entity certificates in the Private Other domain. In fact, these certificates will be issued by TSPs containing only one of `conf` (Confidentiality), `authy` (Authenticity) or `authon` (Authentication). By default, end entity certificates in this domain will be using containing `authon` (Authentication). Others are upon request. 
* Removes `subjectAltNames` from certificate profile as this is provided in the enrollment file. Validation for the `subjectAltNames` remains present in the certificate profile. 
* Adds a minimum length of 2 to enforces that some text must be entered in `subject.serialNumber` and `subject.commonName`.