### PR TITLE
Maintain an event log for activities

### DIFF
--- a/create-ca.py
+++ b/create-ca.py
@@ -1,12 +1,17 @@
+import logging
+import sys
+
 from lib import cert
 from lib import crl
 from lib.domains import verify
 from lib.keypair import KeyPair
 from lib.util import load_yaml, choose, load_config
 
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+logger = logging.getLogger("create-ca")
+
 
 def main():
-
     config = load_config()
 
     options = load_yaml("domains.yaml")['domains']

--- a/lib/cert.py
+++ b/lib/cert.py
@@ -11,6 +11,7 @@ from cryptography.x509 import UnrecognizedExtension
 from cryptography.x509.oid import ObjectIdentifier
 
 from .dn import as_name, generate_basename
+from .events import log_issued_cert
 from .keypair import KeyPair, get_hash_algo
 from .ra import validate
 from .util import force_int, keys_exist, load_yaml
@@ -161,7 +162,7 @@ def handle_extensions(builder, ext, enrollment, subject_keys, ca_keys):
     return builder
 
 
-def sign(profile:dict, enrollment:dict, issuer:dict, subject_keys:KeyPair, issuer_keys:KeyPair, config:dict):
+def sign(profile:dict, enrollment:dict, issuer:dict, subject_keys:KeyPair, issuer_keys:KeyPair, config:dict) -> x509.Certificate:
 
     logger.debug(f"Signing certificate {as_name(enrollment['subject']).rfc4514_string()} using {as_name(issuer['subject']).rfc4514_string()}")
 
@@ -267,5 +268,7 @@ def process(profile: dict, enrollment: dict, subject_keys: KeyPair, config: dict
     filename = subject_keys.certificatefile
     with open(filename, "wb") as f:
         f.write(cert.public_bytes(serialization.Encoding.DER))
+
+    log_issued_cert(cert)
 
     logger.info(f"Certificate issued and saved to {filename}")

--- a/lib/crl.py
+++ b/lib/crl.py
@@ -9,9 +9,9 @@ from cryptography.x509 import ReasonFlags, load_der_x509_crl
 from cryptography.x509.extensions import BasicConstraints
 from jschon import create_catalog, JSON, JSONSchema
 
+from .events import log_signed_crl
 from .keypair import KeyPair
-from .util import force_int
-from .util import load_yaml, eprint, output_errors
+from .util import force_int, load_yaml, output_errors
 
 logger = logging.getLogger(__name__)
 
@@ -133,5 +133,7 @@ def process(revocationfile, config, force=False):
     # Write to disk
     with open(filename, "wb") as f:
         f.write(crl.public_bytes(serialization.Encoding.DER))
+
+    log_signed_crl(crl)
 
     logger.info(f"Signed CRL with number {current_crl_number+1} containing {len(profile['revocations'])} revocations and saved to {filename}")

--- a/lib/events.py
+++ b/lib/events.py
@@ -1,0 +1,29 @@
+import logging
+import os
+
+from cryptography import x509
+from cryptography.x509.extensions import AuthorityKeyIdentifier
+
+if not os.path.isdir('ca'):
+    os.mkdir('ca')
+
+eventlog = logging.getLogger('events')
+file_handler = logging.FileHandler(filename=os.path.join('ca', 'events.txt'))
+formatter = logging.Formatter('%(asctime)s;%(name)s;%(levelname)s;%(message)s')
+file_handler.setFormatter(formatter)
+eventlog.addHandler(file_handler)
+
+
+def log(msg: str):
+    eventlog.info(msg)
+
+
+def log_issued_cert(cert: x509.Certificate):
+    aki = cert.extensions.get_extension_for_class(AuthorityKeyIdentifier).value.key_identifier.hex()
+    log(f"issued;{aki};{cert.serial_number}")
+
+
+def log_signed_crl(crl: x509.CertificateRevocationList):
+    aki = crl.extensions.get_extension_for_class(AuthorityKeyIdentifier).value.key_identifier.hex()
+    crl_number = crl.extensions.get_extension_for_class(x509.CRLNumber).value.crl_number
+    log(f"crl;{aki};{crl_number}")


### PR DESCRIPTION
This PR: 
* Adds a rudimentary event log for CA actions. This is a prerequisite for a possible OCSP Responder. 