### PR TITLE
Enable signing CRLs using encrypted private keys

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -229,15 +229,32 @@ jobs:
       - name: Check
         run: ls ca/certs/TRIALPKIoverheidG4RootPrivGTLS2024.cer
 
-      - name: Use without password (fails)
+      - name: Generate CRL without password (yet it requires it)
+        run: "! python generate-crl.py revocations/TRIALPKIoverheidG4RootPrivGTLS2024.yaml"
+
+      - name: Check (fails)
+        run: "! ls ca/crl/TRIALPKIoverheidG4RootPrivGTLS2024.crl"
+
+      - name: Generate CRL with wrong password
+        run: "! python generate-crl.py --issuer-password WrongPassword revocations/TRIALPKIoverheidG4RootPrivGTLS2024.yaml"
+
+      - name: Check (fails)
+        run: "! ls ca/crl/TRIALPKIoverheidG4RootPrivGTLS2024.crl"
+
+      - name: Generate CRL with correct password
+        run: python generate-crl.py --issuer-password RootPassword1 revocations/TRIALPKIoverheidG4RootPrivGTLS2024.yaml
+
+      - name: Check
+        run: ls ca/crl/TRIALPKIoverheidG4RootPrivGTLS2024.crl
+
+      - name: Issue without password (fails)
         run: "! python generate-cert.py enrollment/TRIALPKIoverheidG4IntmPrivGTLSSYS2024.yaml"
 
       - name: Check (fails)
         run: "! ls ca/certs/TRIALPKIoverheidG4IntmPrivGTLSSYS2024.cer"
 
-      - name: Use with password
+      - name: Issue with password
         run: python generate-cert.py --issuer-password RootPassword1 --subject-password DomainPassword1 "enrollment/TRIALPKIoverheidG4IntmPrivGTLSSYS2024.yaml"
 
       - name: Check
         run: ls ca/certs/TRIALPKIoverheidG4IntmPrivGTLSSYS2024.cer
-

--- a/generate-crl.py
+++ b/generate-crl.py
@@ -12,6 +12,7 @@ logger = logging.getLogger("generate-crl")
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-f', '--force', action='store_true', help="If files are absent, generate boilerplate YAML and CRL files")
+    parser.add_argument('--issuer-password', action="store", help="Password to decrypt issuer's private key")
     parser.add_argument('revocations', nargs='+', help="Generate CRLs for these files")
     args = parser.parse_args()
 
@@ -19,7 +20,7 @@ def main():
 
     for filename in args.revocations:
         logger.info(f"Processing {filename}")
-        crl.process(filename, config, args.force)
+        crl.process(filename, config, args.force, issuer_password=args.issuer_password)
 
 
 if __name__ == "__main__":

--- a/lib/crl.py
+++ b/lib/crl.py
@@ -80,10 +80,10 @@ catalog = create_catalog("2020-12")
 schema = JSONSchema.loadf(os.path.join('schema', 'revocations.json'))
 
 
-def process(revocationfile, config, force=False):
+def process(revocationfile, config, force=False, issuer_password=None):
 
     # Find keys
-    ca_keys = KeyPair.for_filename(revocationfile).load()
+    ca_keys = KeyPair.for_filename(revocationfile).load(password=issuer_password)
 
     # Check must be a CA
     basic_constraints = ca_keys.certificate.extensions.get_extension_for_class(BasicConstraints).value


### PR DESCRIPTION
#24 introduced the ability to use encrypted private keys. However this functionality was not extended to issuing CRLs. 

This PR:
* Adds the ability to sign CRLs using an encrypted private key using the `--issuer-password` flag. 