### PR TITLE
Let `subject.organization` start with "TRIAL"

### DIFF
--- a/enrollment/TRIALMyTSPG4PKIoPrivGOtherLP2025.yaml
+++ b/enrollment/TRIALMyTSPG4PKIoPrivGOtherLP2025.yaml
@@ -2,6 +2,6 @@
 profile: profiles/G4TRIALPKIoPrivGOtherLP2025.yaml
 subject:
   C: NL
+  O: TRIAL My TSP - not for Production use
   CN: TRIAL My TSP - G4 PKIo Priv G-Other LP - 2025
-  O: My TSP - not for Production use
   organizationIdentifier: NTRNL-99999990

--- a/enrollment/TRIALMyTSPG4PKIoPrivGOtherNP2025.yaml
+++ b/enrollment/TRIALMyTSPG4PKIoPrivGOtherNP2025.yaml
@@ -2,6 +2,6 @@
 profile: profiles/G4TRIALPKIoPrivGOtherNP2025.yaml
 subject:
   C: NL
+  O: TRIAL My TSP - not for Production use
   CN: TRIAL My TSP - G4 PKIo Priv G-Other NP - 2025
-  O: My TSP - not for Production use
   organizationIdentifier: NTRNL-99999990

--- a/enrollment/TRIALMyTSPG4PKIoPrivGTLSSYS2025.yaml
+++ b/enrollment/TRIALMyTSPG4PKIoPrivGTLSSYS2025.yaml
@@ -2,6 +2,6 @@
 profile: profiles/G4TRIALPKIoPrivGTLSSYS2025.yaml
 subject:
   C: NL
+  O: TRIAL My TSP - not for Production use
   CN: TRIAL My TSP - G4 PKIo Priv G-TLS SYS - 2025
-  O: My TSP - not for Production use
   organizationIdentifier: NTRNL-99999990

--- a/enrollment/TRIALPKIoverheidG4IntmPrivGOtherLP2024.yaml
+++ b/enrollment/TRIALPKIoverheidG4IntmPrivGOtherLP2024.yaml
@@ -2,5 +2,5 @@
 profile: profiles/G4TRIALIntmPrivGOtherLP2024.yaml
 subject:
   C: NL
-  CN: TRIAL PKIoverheid - G4 Intm Priv G-Other LP - 2024
   O: TRIAL PKIoverheid - not for Production use
+  CN: TRIAL PKIoverheid - G4 Intm Priv G-Other LP - 2024

--- a/enrollment/TRIALPKIoverheidG4IntmPrivGOtherNP2024.yaml
+++ b/enrollment/TRIALPKIoverheidG4IntmPrivGOtherNP2024.yaml
@@ -2,5 +2,5 @@
 profile: profiles/G4TRIALIntmPrivGOtherNP2024.yaml
 subject:
   C: NL
-  CN: TRIAL PKIoverheid - G4 Intm Priv G-Other NP - 2024
   O: TRIAL PKIoverheid - not for Production use
+  CN: TRIAL PKIoverheid - G4 Intm Priv G-Other NP - 2024

--- a/enrollment/TRIALPKIoverheidG4IntmPrivGTLSSYS2024.yaml
+++ b/enrollment/TRIALPKIoverheidG4IntmPrivGTLSSYS2024.yaml
@@ -2,5 +2,5 @@
 profile: profiles/G4TRIALIntmPrivGTLSSYS2024.yaml
 subject:
   C: NL
-  CN: TRIAL PKIoverheid - G4 Intm Priv G-TLS SYS - 2024
   O: TRIAL PKIoverheid - not for Production use
+  CN: TRIAL PKIoverheid - G4 Intm Priv G-TLS SYS - 2024

--- a/enrollment/TRIALPKIoverheidG4RootPrivGOther2024.yaml
+++ b/enrollment/TRIALPKIoverheidG4RootPrivGOther2024.yaml
@@ -2,5 +2,5 @@
 profile: profiles/G4TRIALRootPrivGOther2024.yaml
 subject:
   C: NL
-  CN: TRIAL PKIoverheid - G4 Root Priv G-Other - 2024
   O: TRIAL PKIoverheid - not for Production use
+  CN: TRIAL PKIoverheid - G4 Root Priv G-Other - 2024

--- a/enrollment/TRIALPKIoverheidG4RootPrivGTLS2024.yaml
+++ b/enrollment/TRIALPKIoverheidG4RootPrivGTLS2024.yaml
@@ -2,5 +2,5 @@
 profile: profiles/G4TRIALRootPrivGTLS2024.yaml
 subject:
   C: NL
-  CN: TRIAL PKIoverheid - G4 Root Priv G-TLS - 2024
   O: TRIAL PKIoverheid - not for Production use
+  CN: TRIAL PKIoverheid - G4 Root Priv G-TLS - 2024

--- a/profiles/G4TRIALEEPrivGOtherLP2025.yaml
+++ b/profiles/G4TRIALEEPrivGOtherLP2025.yaml
@@ -74,11 +74,12 @@ validations:
         CN:
           maxLength: 64
           minLength: 5
-          pattern: ^TRIAL .*
+          pattern: '^TRIAL '
           type: string
         O:
           maxLength: 64
           minLength: 2
+          pattern: '^TRIAL '
           type: string
         organizationIdentifier:
           maxLength: 64

--- a/profiles/G4TRIALEEPrivGOtherNP2025IndividualValidated.yaml
+++ b/profiles/G4TRIALEEPrivGOtherNP2025IndividualValidated.yaml
@@ -67,7 +67,7 @@ validations:
         CN:
           maxLength: 64
           minLength: 5
-          pattern: ^TRIAL .*
+          pattern: '^TRIAL '
           type: string
         GN:
           maxLength: 64

--- a/profiles/G4TRIALEEPrivGOtherNP2025RegulatedProfession.yaml
+++ b/profiles/G4TRIALEEPrivGOtherNP2025RegulatedProfession.yaml
@@ -67,7 +67,7 @@ validations:
         CN:
           maxLength: 64
           minLength: 5
-          pattern: ^TRIAL .*
+          pattern: '^TRIAL '
           type: string
         GN:
           maxLength: 64

--- a/profiles/G4TRIALEEPrivGOtherNP2025RegulatedProfessionwithSponsorValidation.yaml
+++ b/profiles/G4TRIALEEPrivGOtherNP2025RegulatedProfessionwithSponsorValidation.yaml
@@ -74,7 +74,7 @@ validations:
         CN:
           maxLength: 64
           minLength: 5
-          pattern: ^TRIAL .*
+          pattern: '^TRIAL '
           type: string
         GN:
           maxLength: 64
@@ -83,6 +83,7 @@ validations:
         O:
           maxLength: 64
           minLength: 2
+          pattern: '^TRIAL '
           type: string
         SN:
           maxLength: 64

--- a/profiles/G4TRIALEEPrivGOtherNP2025SponsorValidated.yaml
+++ b/profiles/G4TRIALEEPrivGOtherNP2025SponsorValidated.yaml
@@ -74,7 +74,7 @@ validations:
         CN:
           maxLength: 64
           minLength: 5
-          pattern: ^TRIAL .*
+          pattern: '^TRIAL '
           type: string
         GN:
           maxLength: 64
@@ -83,6 +83,7 @@ validations:
         O:
           maxLength: 64
           minLength: 2
+          pattern: '^TRIAL '
           type: string
         SN:
           maxLength: 64

--- a/profiles/G4TRIALEEPrivGTLSSYS2025.yaml
+++ b/profiles/G4TRIALEEPrivGTLSSYS2025.yaml
@@ -75,11 +75,12 @@ validations:
         CN:
           maxLength: 64
           minLength: 2
-          pattern: ^TRIAL .*
+          pattern: '^TRIAL '
           type: string
         O:
           maxLength: 64
           minLength: 2
+          pattern: '^TRIAL '
           type: string
         organizationIdentifier:
           pattern: ^NTRNL-[0-9]{8}$

--- a/profiles/G4TRIALIntmPrivGOtherLP2024.yaml
+++ b/profiles/G4TRIALIntmPrivGOtherLP2024.yaml
@@ -82,7 +82,7 @@ validations:
           type: string
         CN:
           allOf:
-          - pattern: TRIAL PKIoverheid - .*
+          - pattern: '^TRIAL PKIoverheid - '
           - pattern: ' - G4 Intm Priv (G-Other|S-CIBG) LP - 20[0-9][0-9](-[0-9]+)?$'
           maxLength: 64
           type: string

--- a/profiles/G4TRIALIntmPrivGOtherNP2024.yaml
+++ b/profiles/G4TRIALIntmPrivGOtherNP2024.yaml
@@ -100,7 +100,7 @@ validations:
           type: string
         CN:
           allOf:
-          - pattern: TRIAL PKIoverheid - .*
+          - pattern: '^TRIAL PKIoverheid - '
           - pattern: ' - G4 Intm Priv (G-Other|S-CIBG) NP - 20[0-9][0-9](-[0-9]+)?$'
           maxLength: 64
           type: string

--- a/profiles/G4TRIALIntmPrivGTLSSYS2024.yaml
+++ b/profiles/G4TRIALIntmPrivGTLSSYS2024.yaml
@@ -74,7 +74,7 @@ validations:
           type: string
         CN:
           allOf:
-          - pattern: TRIAL PKIoverheid - .*
+          - pattern: '^TRIAL PKIoverheid - '
           - pattern: ' - G4 Intm Priv G-TLS SYS - 20[0-9][0-9](-[0-9]+)?$'
           maxLength: 64
           type: string

--- a/profiles/G4TRIALPKIoPrivGOtherLP2025.yaml
+++ b/profiles/G4TRIALPKIoPrivGOtherLP2025.yaml
@@ -86,13 +86,13 @@ validations:
           type: string
         CN:
           allOf:
-          - pattern: 'TRIAL .* - '
+          - pattern: ^TRIAL .*
           - pattern: ' - G4 PKIo Priv (G-Other|S-CIBG) LP - 20[0-9][0-9](-[0-9]+)?$'
           maxLength: 64
           type: string
         O:
-          maxLength: 39
-          minLength: 2
+          maxLength: 64
+          pattern: ^TRIAL .* - not for Production use
           type: string
         organizationIdentifier:
           pattern: ^NTRNL-[0-9]{8}$

--- a/profiles/G4TRIALPKIoPrivGOtherNP2025.yaml
+++ b/profiles/G4TRIALPKIoPrivGOtherNP2025.yaml
@@ -104,13 +104,13 @@ validations:
           type: string
         CN:
           allOf:
-          - pattern: 'TRIAL .* - '
+          - pattern: ^TRIAL .*
           - pattern: ' - G4 PKIo Priv (G-Other|S-CIBG) NP - 20[0-9][0-9](-[0-9]+)?$'
           maxLength: 64
           type: string
         O:
-          maxLength: 39
-          minLength: 2
+          maxLength: 64
+          pattern: ^TRIAL .* - not for Production use
           type: string
         organizationIdentifier:
           pattern: ^NTRNL-[0-9]{8}$

--- a/profiles/G4TRIALPKIoPrivGTLSSYS2025.yaml
+++ b/profiles/G4TRIALPKIoPrivGTLSSYS2025.yaml
@@ -78,13 +78,13 @@ validations:
           type: string
         CN:
           allOf:
-          - pattern: 'TRIAL .* - '
+          - pattern: ^TRIAL .*
           - pattern: ' - G4 PKIo Priv G-TLS SYS - 20[0-9][0-9](-[0-9]+)?$'
           maxLength: 64
           type: string
         O:
-          maxLength: 39
-          minLength: 2
+          maxLength: 64
+          pattern: ^TRIAL .* - not for Production use
           type: string
         organizationIdentifier:
           pattern: ^NTRNL-[0-9]{8}$

--- a/profiles/G4TRIALRootPrivGOther2024.yaml
+++ b/profiles/G4TRIALRootPrivGOther2024.yaml
@@ -43,7 +43,7 @@ validations:
           type: string
         CN:
           allOf:
-          - pattern: TRIAL PKIoverheid - .*
+          - pattern: '^TRIAL PKIoverheid - '
           - pattern: ' - G4 Root Priv (G-Other|S-CIBG) - 20[0-9][0-9](-[0-9]+)?$'
           maxLength: 64
           type: string
@@ -61,6 +61,6 @@ validations:
   - subject
   type: object
 validity:
-  notAfter: 2039-05-20 00:00:00
+  notAfter: '2039-05-20T00:00:00'
   notBefore: now
 version: 3 (0x2)

--- a/profiles/G4TRIALRootPrivGTLS2024.yaml
+++ b/profiles/G4TRIALRootPrivGTLS2024.yaml
@@ -43,7 +43,7 @@ validations:
           type: string
         CN:
           allOf:
-          - pattern: TRIAL PKIoverheid - .*
+          - pattern: '^TRIAL PKIoverheid - '
           - pattern: ' - G4 Root Priv G-TLS - 20[0-9][0-9](-[0-9]+)?$'
           maxLength: 64
           type: string
@@ -61,6 +61,6 @@ validations:
   - subject
   type: object
 validity:
-  notAfter: 2039-05-20 00:00:00
+  notAfter: '2039-05-20T00:00:00'
   notBefore: now
 version: 3 (0x2)


### PR DESCRIPTION
This PR:
* Updates enrollment files to use the correct attribute ordering;
* Adds technical validation to `subject.organization`: it must start with "TRIAL";
* Tightens some other technical validations, e.g. `TRIAL .* - ` to `^TRIAL .*` because they need to start with TRIAL. 