### PR TITLE
Automatically set the `caIssuers` and `cRLDistributionPoints`

### DIFF
--- a/lib/cert.py
+++ b/lib/cert.py
@@ -167,10 +167,12 @@ def sign(profile:dict, enrollment:dict, issuer:dict, subject_keys:KeyPair, issue
     logger.debug(f"Signing certificate {as_name(enrollment['subject']).rfc4514_string()} using {as_name(issuer['subject']).rfc4514_string()}")
 
     # Replace placeholders with actual values
+    replacements = config.copy()
+    replacements['issuerBaseName'] = issuer_keys.basename
     if keys_exist(profile, ['extensions', 'authorityInfoAccess', 'caIssuers']):
-        profile['extensions']['authorityInfoAccess']['caIssuers'] = profile['extensions']['authorityInfoAccess']['caIssuers'] % config['caIssuersBaseUrl']
+        profile['extensions']['authorityInfoAccess']['caIssuers'] = profile['extensions']['authorityInfoAccess']['caIssuers'] % replacements
     if keys_exist(profile, ['extensions', 'cRLDistributionPoints', 'value']):
-        profile['extensions']['cRLDistributionPoints']['value'] = [value % config['cRLDistributionPointsBaseUrl'] for value in profile['extensions']['cRLDistributionPoints']['value']]
+        profile['extensions']['cRLDistributionPoints']['value'] = [value % replacements for value in profile['extensions']['cRLDistributionPoints']['value']]
 
     # Validity
     if isinstance(profile['validity']['notBefore'], datetime):

--- a/profiles/G4TRIALEEPrivGOtherLP2025.yaml
+++ b/profiles/G4TRIALEEPrivGOtherLP2025.yaml
@@ -2,7 +2,7 @@
 exponent: 65537 (0x10001)
 extensions:
   authorityInfoAccess:
-    caIssuers: '%s/TRIALMyTSPG4PKIoPrivGOtherLP2025.cer'
+    caIssuers: '%(caIssuersBaseUrl)s/%(issuerBaseName)s.cer'
     critical: false
     oid: 1.3.6.1.5.5.7.1.1
   authorityKeyIdentifier:
@@ -17,7 +17,7 @@ extensions:
     critical: false
     oid: 2.5.29.31
     value:
-    - '%s/TRIALMyTSPG4PKIoPrivGOtherLP2025.crl'
+    - '%(cRLDistributionPointsBaseUrl)s/%(issuerBaseName)s.crl'
   certificatePolicies:
     critical: false
     oid: 2.5.29.32

--- a/profiles/G4TRIALEEPrivGOtherNP2025IndividualValidated.yaml
+++ b/profiles/G4TRIALEEPrivGOtherNP2025IndividualValidated.yaml
@@ -2,7 +2,7 @@
 exponent: 65537 (0x10001)
 extensions:
   authorityInfoAccess:
-    caIssuers: '%s/TRIALMyTSPG4PKIoPrivGOtherNP2025.cer'
+    caIssuers: '%(caIssuersBaseUrl)s/%(issuerBaseName)s.cer'
     critical: false
     oid: 1.3.6.1.5.5.7.1.1
   authorityKeyIdentifier:
@@ -17,7 +17,7 @@ extensions:
     critical: false
     oid: 2.5.29.31
     value:
-    - '%s/TRIALMyTSPG4PKIoPrivGOtherNP2025.crl'
+    - '%(cRLDistributionPointsBaseUrl)s/%(issuerBaseName)s.crl'
   certificatePolicies:
     critical: false
     oid: 2.5.29.32

--- a/profiles/G4TRIALEEPrivGOtherNP2025RegulatedProfession.yaml
+++ b/profiles/G4TRIALEEPrivGOtherNP2025RegulatedProfession.yaml
@@ -2,7 +2,7 @@
 exponent: 65537 (0x10001)
 extensions:
   authorityInfoAccess:
-    caIssuers: '%s/TRIALMyTSPG4PKIoPrivGOtherNP2025.cer'
+    caIssuers: '%(caIssuersBaseUrl)s/%(issuerBaseName)s.cer'
     critical: false
     oid: 1.3.6.1.5.5.7.1.1
   authorityKeyIdentifier:
@@ -17,7 +17,7 @@ extensions:
     critical: false
     oid: 2.5.29.31
     value:
-    - '%s/TRIALMyTSPG4PKIoPrivGOtherNP2025.crl'
+    - '%(cRLDistributionPointsBaseUrl)s/%(issuerBaseName)s.crl'
   certificatePolicies:
     critical: false
     oid: 2.5.29.32

--- a/profiles/G4TRIALEEPrivGOtherNP2025RegulatedProfessionwithSponsorValidation.yaml
+++ b/profiles/G4TRIALEEPrivGOtherNP2025RegulatedProfessionwithSponsorValidation.yaml
@@ -2,7 +2,7 @@
 exponent: 65537 (0x10001)
 extensions:
   authorityInfoAccess:
-    caIssuers: '%s/TRIALMyTSPG4PKIoPrivGOtherNP2025.cer'
+    caIssuers: '%(caIssuersBaseUrl)s/%(issuerBaseName)s.cer'
     critical: false
     oid: 1.3.6.1.5.5.7.1.1
   authorityKeyIdentifier:
@@ -17,7 +17,7 @@ extensions:
     critical: false
     oid: 2.5.29.31
     value:
-    - '%s/TRIALMyTSPG4PKIoPrivGOtherNP2025.crl'
+    - '%(cRLDistributionPointsBaseUrl)s/%(issuerBaseName)s.crl'
   certificatePolicies:
     critical: false
     oid: 2.5.29.32

--- a/profiles/G4TRIALEEPrivGOtherNP2025SponsorValidated.yaml
+++ b/profiles/G4TRIALEEPrivGOtherNP2025SponsorValidated.yaml
@@ -2,7 +2,7 @@
 exponent: 65537 (0x10001)
 extensions:
   authorityInfoAccess:
-    caIssuers: '%s/TRIALMyTSPG4PKIoPrivGOtherNP2025.cer'
+    caIssuers: '%(caIssuersBaseUrl)s/%(issuerBaseName)s.cer'
     critical: false
     oid: 1.3.6.1.5.5.7.1.1
   authorityKeyIdentifier:
@@ -17,7 +17,7 @@ extensions:
     critical: false
     oid: 2.5.29.31
     value:
-    - '%s/TRIALMyTSPG4PKIoPrivGOtherNP2025.crl'
+    - '%(cRLDistributionPointsBaseUrl)s/%(issuerBaseName)s.crl'
   certificatePolicies:
     critical: false
     oid: 2.5.29.32

--- a/profiles/G4TRIALEEPrivGTLSSYS2025.yaml
+++ b/profiles/G4TRIALEEPrivGTLSSYS2025.yaml
@@ -2,7 +2,7 @@
 exponent: 65537 (0x10001)
 extensions:
   authorityInfoAccess:
-    caIssuers: '%s/TRIALMyTSPG4PKIoPrivGTLSSYS2025.cer'
+    caIssuers: '%(caIssuersBaseUrl)s/%(issuerBaseName)s.cer'
     critical: false
     oid: 1.3.6.1.5.5.7.1.1
   authorityKeyIdentifier:
@@ -17,7 +17,7 @@ extensions:
     critical: false
     oid: 2.5.29.31
     value:
-    - '%s/TRIALMyTSPG4PKIoPrivGTLSSYS2025.crl'
+    - '%(cRLDistributionPointsBaseUrl)s/%(issuerBaseName)s.crl'
   certificatePolicies:
     critical: false
     oid: 2.5.29.32

--- a/profiles/G4TRIALIntmPrivGOtherLP2024.yaml
+++ b/profiles/G4TRIALIntmPrivGOtherLP2024.yaml
@@ -2,7 +2,7 @@
 exponent: 65537 (0x10001)
 extensions:
   authorityInfoAccess:
-    caIssuers: '%s/TRIALPKIoverheidG4RootPrivGOther2024.cer'
+    caIssuers: '%(caIssuersBaseUrl)s/%(issuerBaseName)s.cer'
     critical: false
     oid: 1.3.6.1.5.5.7.1.1
   authorityKeyIdentifier:
@@ -17,7 +17,7 @@ extensions:
     critical: false
     oid: 2.5.29.31
     value:
-    - '%s/TRIALPKIoverheidG4RootPrivGOther2024.crl'
+    - '%(cRLDistributionPointsBaseUrl)s/%(issuerBaseName)s.crl'
   certificatePolicies:
     critical: false
     oid: 2.5.29.32

--- a/profiles/G4TRIALIntmPrivGOtherNP2024.yaml
+++ b/profiles/G4TRIALIntmPrivGOtherNP2024.yaml
@@ -2,7 +2,7 @@
 exponent: 65537 (0x10001)
 extensions:
   authorityInfoAccess:
-    caIssuers: '%s/TRIALPKIoverheidG4RootPrivGOther2024.cer'
+    caIssuers: '%(caIssuersBaseUrl)s/%(issuerBaseName)s.cer'
     critical: false
     oid: 1.3.6.1.5.5.7.1.1
   authorityKeyIdentifier:
@@ -17,7 +17,7 @@ extensions:
     critical: false
     oid: 2.5.29.31
     value:
-    - '%s/TRIALPKIoverheidG4RootPrivGOther2024.crl'
+    - '%(cRLDistributionPointsBaseUrl)s/%(issuerBaseName)s.crl'
   certificatePolicies:
     critical: false
     oid: 2.5.29.32

--- a/profiles/G4TRIALIntmPrivGTLSSYS2024.yaml
+++ b/profiles/G4TRIALIntmPrivGTLSSYS2024.yaml
@@ -2,7 +2,7 @@
 exponent: 65537 (0x10001)
 extensions:
   authorityInfoAccess:
-    caIssuers: '%s/TRIALPKIoverheidG4RootPrivGTLS2024.cer'
+    caIssuers: '%(caIssuersBaseUrl)s/%(issuerBaseName)s.cer'
     critical: false
     oid: 1.3.6.1.5.5.7.1.1
   authorityKeyIdentifier:
@@ -17,7 +17,7 @@ extensions:
     critical: false
     oid: 2.5.29.31
     value:
-    - '%s/TRIALPKIoverheidG4RootPrivGTLS2024.crl'
+    - '%(cRLDistributionPointsBaseUrl)s/%(issuerBaseName)s.crl'
   certificatePolicies:
     critical: false
     oid: 2.5.29.32

--- a/profiles/G4TRIALPKIoPrivGOtherLP2025.yaml
+++ b/profiles/G4TRIALPKIoPrivGOtherLP2025.yaml
@@ -2,7 +2,7 @@
 exponent: 65537 (0x10001)
 extensions:
   authorityInfoAccess:
-    caIssuers: '%s/TRIALPKIoverheidG4IntmPrivGOtherLP2024.cer'
+    caIssuers: '%(caIssuersBaseUrl)s/%(issuerBaseName)s.cer'
     critical: false
     oid: 1.3.6.1.5.5.7.1.1
   authorityKeyIdentifier:
@@ -18,7 +18,7 @@ extensions:
     critical: false
     oid: 2.5.29.31
     value:
-    - '%s/TRIALPKIoverheidG4IntmPrivGOtherLP2024.crl'
+    - '%(cRLDistributionPointsBaseUrl)s/%(issuerBaseName)s.crl'
   certificatePolicies:
     critical: false
     oid: 2.5.29.32

--- a/profiles/G4TRIALPKIoPrivGOtherNP2025.yaml
+++ b/profiles/G4TRIALPKIoPrivGOtherNP2025.yaml
@@ -2,7 +2,7 @@
 exponent: 65537 (0x10001)
 extensions:
   authorityInfoAccess:
-    caIssuers: '%s/TRIALPKIoverheidG4IntmPrivGOtherNP2024.cer'
+    caIssuers: '%(caIssuersBaseUrl)s/%(issuerBaseName)s.cer'
     critical: false
     oid: 1.3.6.1.5.5.7.1.1
   authorityKeyIdentifier:
@@ -18,7 +18,7 @@ extensions:
     critical: false
     oid: 2.5.29.31
     value:
-    - '%s/TRIALPKIoverheidG4IntmPrivGOtherNP2024.crl'
+    - '%(cRLDistributionPointsBaseUrl)s/%(issuerBaseName)s.crl'
   certificatePolicies:
     critical: false
     oid: 2.5.29.32

--- a/profiles/G4TRIALPKIoPrivGTLSSYS2025.yaml
+++ b/profiles/G4TRIALPKIoPrivGTLSSYS2025.yaml
@@ -2,7 +2,7 @@
 exponent: 65537 (0x10001)
 extensions:
   authorityInfoAccess:
-    caIssuers: '%s/TRIALPKIoverheidG4IntmPrivGTLSSYS2024.cer'
+    caIssuers: '%(caIssuersBaseUrl)s/%(issuerBaseName)s.cer'
     critical: false
     oid: 1.3.6.1.5.5.7.1.1
   authorityKeyIdentifier:
@@ -18,7 +18,7 @@ extensions:
     critical: false
     oid: 2.5.29.31
     value:
-    - '%s/TRIALPKIoverheidG4IntmPrivGTLSSYS2024.crl'
+    - '%(cRLDistributionPointsBaseUrl)s/%(issuerBaseName)s.crl'
   certificatePolicies:
     critical: false
     oid: 2.5.29.32


### PR DESCRIPTION
This PR:
* Modifies the values in certificate profiles so that the `caIssuers` and `cRLDistributionPoints` values can automatically be deduced from the issuer's filename. This reduces the chance of having incorrect values. 