### PR TITLE
Private Other follows NCP certificate policy, not NCP+

### DIFF
--- a/profiles/G4TRIALEEPrivGOtherLP2025.yaml
+++ b/profiles/G4TRIALEEPrivGOtherLP2025.yaml
@@ -24,8 +24,6 @@ extensions:
     value:
     - name: ncp
       oid: 0.4.0.2042.1.1
-    - name: ncpplus
-      oid: 0.4.0.2042.1.2
     - name: id-pkio-cp-g4d-gen10PrvOth-lpOrg-authon
       oid: 2.16.528.1.1003.1.2.41.16.25.8
   extendedKeyUsage:

--- a/profiles/G4TRIALEEPrivGOtherNP2025IndividualValidated.yaml
+++ b/profiles/G4TRIALEEPrivGOtherNP2025IndividualValidated.yaml
@@ -24,8 +24,6 @@ extensions:
     value:
     - name: ncp
       oid: 0.4.0.2042.1.1
-    - name: ncpplus
-      oid: 0.4.0.2042.1.2
     - name: id-pkio-cp-g4d-gen10PrvOth-npInd-authon
       oid: 2.16.528.1.1003.1.2.41.16.11.8
   extendedKeyUsage:

--- a/profiles/G4TRIALEEPrivGOtherNP2025RegulatedProfession.yaml
+++ b/profiles/G4TRIALEEPrivGOtherNP2025RegulatedProfession.yaml
@@ -24,8 +24,6 @@ extensions:
     value:
     - name: ncp
       oid: 0.4.0.2042.1.1
-    - name: ncpplus
-      oid: 0.4.0.2042.1.2
     - name: id-pkio-cp-g4d-gen10PrvOth-npRegP-authon
       oid: 2.16.528.1.1003.1.2.41.16.12.8
   extendedKeyUsage:

--- a/profiles/G4TRIALEEPrivGOtherNP2025RegulatedProfessionwithSponsorValidation.yaml
+++ b/profiles/G4TRIALEEPrivGOtherNP2025RegulatedProfessionwithSponsorValidation.yaml
@@ -24,8 +24,6 @@ extensions:
     value:
     - name: ncp
       oid: 0.4.0.2042.1.1
-    - name: ncpplus
-      oid: 0.4.0.2042.1.2
     - name: id-pkio-cp-g4d-gen10PrvOth-npRPSp-authon
       oid: 2.16.528.1.1003.1.2.41.16.14.8
   extendedKeyUsage:

--- a/profiles/G4TRIALEEPrivGOtherNP2025SponsorValidated.yaml
+++ b/profiles/G4TRIALEEPrivGOtherNP2025SponsorValidated.yaml
@@ -24,8 +24,6 @@ extensions:
     value:
     - name: ncp
       oid: 0.4.0.2042.1.1
-    - name: ncpplus
-      oid: 0.4.0.2042.1.2
     - name: id-pkio-cp-g4d-gen10PrvOth-npSpon-authon
       oid: 2.16.528.1.1003.1.2.41.16.13.8
   extendedKeyUsage:


### PR DESCRIPTION
PoR Section [7.1.6.4 Subscriber Certificates](https://cp.pkioverheid.nl/pkioverheid-por-v5.3.html#id__7164-subscriber-certificates) indicates that the NCP+ policy assertion is only permitted if the TSP provisions the Secure Cryptographic Device (SCD). In most cases that only applies to Qualified certificates, not to Private Other certificates. 

Nevertheless, subscribers may still choose to use a SCD, but it wouldn't be asserted in the certificate. 