### PR TITLE
Clarify that a fauxTSP may offer all certificate types

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 This tool allows you to generate TRIAL (test) certificates for the PKIoverheid G4 hierarchies yourself. It generates a complete hierarchy of certificates resembling a chosen G4 hierarchy. For more information on these hierarchies, please refer to the [PKIoverheid CPS, Section 1.1](https://cps.pkioverheid.nl/pkioverheid-cps-unified-v5.4.html#id__11-overview).
 
-G4 TRIAL end entity certificates for testing purposes can be acquired free of charge from the following organisation(s):
+G4 TRIAL end entity certificates for testing purposes can be acquired free of charge from the following organisation(s); however, when certificates are issued on physical tokens, a fee may apply. 
 
 * [PKIpartners](https://www.pkipartners.nl/g4-trial)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 This tool allows you to generate TRIAL (test) certificates for the PKIoverheid G4 hierarchies yourself. It generates a complete hierarchy of certificates resembling a chosen G4 hierarchy. For more information on these hierarchies, please refer to the [PKIoverheid CPS, Section 1.1](https://cps.pkioverheid.nl/pkioverheid-cps-unified-v5.4.html#id__11-overview).
 
-If you need just a few G4 TRIAL end entity certificates for testing purposes, the following organisation(s) issue these for free:
+G4 TRIAL end entity certificates for testing purposes can be acquired free of charge from the following organisation(s):
 
 * [PKIpartners](https://www.pkipartners.nl/g4-trial)
 


### PR DESCRIPTION
This PR updates the the introduction to this repository, since the text "a few [...] certificates" could be interpreted as "a few certificate types", which is not the case. 