### PR TITLE
Upgrade actions/checkout to v6

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -42,7 +42,7 @@ jobs:
       - unittests
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
         with:
@@ -77,7 +77,7 @@ jobs:
       - unittests
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
         with:
@@ -119,7 +119,7 @@ jobs:
       - unittests
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
         with:
@@ -148,7 +148,7 @@ jobs:
       - unittests
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
         with:
@@ -191,7 +191,7 @@ jobs:
       - unittests
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
         with:
@@ -226,7 +226,7 @@ jobs:
       - unittests
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
         with:
@@ -261,7 +261,7 @@ jobs:
       - unittests
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
         with:
@@ -288,7 +288,7 @@ jobs:
       - unittests
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
         with:
@@ -340,7 +340,7 @@ jobs:
       - unittests
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
This PR:
* Upgrades the Github workflow to use actions/checkout to v6