### PR TITLE
Cleanup hierarchy definitions in `domains.yaml`

### DIFF
--- a/create-ca.py
+++ b/create-ca.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from pathlib import Path
 
 from lib import cert
 from lib import crl
@@ -20,16 +21,22 @@ def main():
 
     hierarchy = choose("Choose a domain:", list(options.keys()))
 
-    # Creating a hierarchy means creating a number of keys
-    for layer in options[hierarchy]['hierarchy']:
-        subject_keys = KeyPair.for_filename(layer['enrollment'])
-        cert.process(load_yaml(layer['profile']), load_yaml(layer['enrollment']), subject_keys, config)
-        crl.process(layer['revocations'], config, force=True)
+    enrollmentfiles = options[hierarchy]
+    revocationfiles = [Path("revocations").joinpath(Path(enrollmentfile).name) for enrollmentfile in enrollmentfiles]
+
+    # Creating a hierarchy is simply creating the certificates and CRLs in sequence
+    for enrollmentfile, revocationfile in zip(enrollmentfiles, revocationfiles):
+        enrollment = load_yaml(enrollmentfile)
+        profile = load_yaml(enrollment['profile'])
+        subject_keys = KeyPair.for_filename(enrollmentfile)
+        cert.process(profile, enrollment, subject_keys, config)
+        crl.process(revocationfile, config, force=True)
 
     print(f'To automate this step, run next time:')
-    for layer in options[hierarchy]['hierarchy']:
-        print(f'python generate-cert.py "{layer['enrollment']}"')
-        print(f'python generate-crl.py --force "{layer['revocations']}"')
+    filenames = "\' \'".join(enrollmentfiles)
+    print(f'python generate-cert.py \'{filenames}\'')
+    filenames = "\' \'".join([str(f) for f in revocationfiles])
+    print(f'python generate-crl.py --force \'{filenames}\'')
 
 
 if __name__ == "__main__":

--- a/domains.yaml
+++ b/domains.yaml
@@ -3,71 +3,26 @@
 domains:
 
   G4 Private TLS:
-    hierarchy:
-      - profile: profiles/G4TRIALRootPrivGTLS2024.yaml
-        enrollment: enrollment/TRIALPKIoverheidG4RootPrivGTLS2024.yaml
-        revocations: revocations/TRIALPKIoverheidG4RootPrivGTLS2024.yaml
-
-      - profile: profiles/G4TRIALIntmPrivGTLSSYS2024.yaml
-        enrollment: enrollment/TRIALPKIoverheidG4IntmPrivGTLSSYS2024.yaml
-        revocations: revocations/TRIALPKIoverheidG4IntmPrivGTLSSYS2024.yaml
-
-      - profile: profiles/G4TRIALPKIoPrivGTLSSYS2025.yaml
-        enrollment: enrollment/TRIALMyTSPG4PKIoPrivGTLSSYS2025.yaml
-        revocations: revocations/TRIALMyTSPG4PKIoPrivGTLSSYS2025.yaml
-
+    - enrollment/TRIALPKIoverheidG4RootPrivGTLS2024.yaml
+    - enrollment/TRIALPKIoverheidG4IntmPrivGTLSSYS2024.yaml
+    - enrollment/TRIALMyTSPG4PKIoPrivGTLSSYS2025.yaml
+        
   G4 Private Other Generic NP:
-    hierarchy:
-      - profile: profiles/G4TRIALRootPrivGOther2024.yaml
-        enrollment: enrollment/TRIALPKIoverheidG4RootPrivGOther2024.yaml
-        revocations: revocations/TRIALPKIoverheidG4RootPrivGOther2024.yaml
-
-      - profile: profiles/G4TRIALIntmPrivGOtherNP2024.yaml
-        enrollment: enrollment/TRIALPKIoverheidG4IntmPrivGOtherNP2024.yaml
-        revocations: revocations/TRIALPKIoverheidG4IntmPrivGOtherNP2024.yaml
-
-      - profile: profiles/G4TRIALPKIoPrivGOtherNP2025.yaml
-        enrollment: enrollment/TRIALMyTSPG4PKIoPrivGOtherNP2025.yaml
-        revocations: revocations/TRIALMyTSPG4PKIoPrivGOtherNP2025.yaml
+    - enrollment/TRIALPKIoverheidG4RootPrivGOther2024.yaml
+    - enrollment/TRIALPKIoverheidG4IntmPrivGOtherNP2024.yaml
+    - enrollment/TRIALMyTSPG4PKIoPrivGOtherNP2025.yaml
 
   G4 Private Other Generic LP:
-    hierarchy:
-      - profile: profiles/G4TRIALRootPrivGOther2024.yaml
-        enrollment: enrollment/TRIALPKIoverheidG4RootPrivGOther2024.yaml
-        revocations: revocations/TRIALPKIoverheidG4RootPrivGOther2024.yaml
-
-      - profile: profiles/G4TRIALIntmPrivGOtherLP2024.yaml
-        enrollment: enrollment/TRIALPKIoverheidG4IntmPrivGOtherLP2024.yaml
-        revocations: revocations/TRIALPKIoverheidG4IntmPrivGOtherLP2024.yaml
-
-      - profile: profiles/G4TRIALPKIoPrivGOtherLP2025.yaml
-        enrollment: enrollment/TRIALMyTSPG4PKIoPrivGOtherLP2025.yaml
-        revocations: revocations/TRIALMyTSPG4PKIoPrivGOtherLP2025.yaml
-
+    - enrollment/TRIALPKIoverheidG4RootPrivGOther2024.yaml
+    - enrollment/TRIALPKIoverheidG4IntmPrivGOtherLP2024.yaml
+    - enrollment/TRIALMyTSPG4PKIoPrivGOtherLP2025.yaml
+        
   G4 EUTL Signatures Generic Natural Persons:
-    hierarchy:
-      - profile: profiles/G4TRIALRootEUTLGSigs2024.yaml
-        enrollment: enrollment/TRIALPKIoverheidG4RootEUTLGSigs2026.yaml
-        revocations: revocations/TRIALPKIoverheidG4RootEUTLGSigs2026.yaml
-
-      - profile: profiles/G4TRIALIntmEUTLGSigsNP2024.yaml
-        enrollment: enrollment/TRIALPKIoverheidG4IntmEUTLGSigsNP2026.yaml
-        revocations: revocations/TRIALPKIoverheidG4IntmEUTLGSigsNP2026.yaml
-
-      - profile: profiles/G4TRIALPKIoEUTLGSigsNP2024.yaml
-        enrollment: enrollment/TRIALMyTSPG4PKIoEUTLGSigsNP2026.yaml
-        revocations: revocations/TRIALMyTSPG4PKIoEUTLGSigsNP2026.yaml
-
+    - enrollment/TRIALPKIoverheidG4RootEUTLGSigs2026.yaml
+    - enrollment/TRIALPKIoverheidG4IntmEUTLGSigsNP2026.yaml
+    - enrollment/TRIALMyTSPG4PKIoEUTLGSigsNP2026.yaml
+        
   G4 EUTL Signatures Generic Legal Persons:
-    hierarchy:
-      - profile: profiles/G4TRIALRootEUTLGSigs2024.yaml
-        enrollment: enrollment/TRIALPKIoverheidG4RootEUTLGSigs2026.yaml
-        revocations: revocations/TRIALPKIoverheidG4RootEUTLGSigs2026.yaml
-
-      - profile: profiles/G4TRIALIntmEUTLGSigsLP2024.yaml
-        enrollment: enrollment/TRIALPKIoverheidG4IntmEUTLGSigsLP2026.yaml
-        revocations: revocations/TRIALPKIoverheidG4IntmEUTLGSigsLP2026.yaml
-
-      - profile: profiles/G4TRIALPKIoEUTLGSigsLP2024.yaml
-        enrollment: enrollment/TRIALMyTSPG4PKIoEUTLGSigsLP2026.yaml
-        revocations: revocations/TRIALMyTSPG4PKIoEUTLGSigsLP2026.yaml
+    - enrollment/TRIALPKIoverheidG4RootEUTLGSigs2026.yaml
+    - enrollment/TRIALPKIoverheidG4IntmEUTLGSigsLP2026.yaml
+    - enrollment/TRIALMyTSPG4PKIoEUTLGSigsLP2026.yaml

--- a/enrollment/TRIALPKIoverheidG4RootEUTLGSigs2026.yaml
+++ b/enrollment/TRIALPKIoverheidG4RootEUTLGSigs2026.yaml
@@ -1,5 +1,5 @@
 ---
-profile: profiles/G4TRIALRootEUTLGSigs2026.yaml
+profile: profiles/G4TRIALRootEUTLGSigs2024.yaml
 subject:
   C: NL
   O: TRIAL PKIoverheid - not for Production use

--- a/lib/domains.py
+++ b/lib/domains.py
@@ -1,33 +1,25 @@
 import os
 
+from lib.util import load_yaml
+
 
 def verify(data):
-
-    def collect_file_paths(data):
-        paths = []
-
-        for domain, content in data.items():
-            # Check hierarchy items
-            for item in content.get('hierarchy', []):
-                for key in ('profile', 'enrollment', 'revocations'):
-                    if key in item:
-                        paths.append(item[key])
-
-            # Check endentity items
-            for item in content.get('endentity', []):
-                if 'profile' in item:
-                    paths.append(item['profile'])
-
-        return paths
-
-    paths = collect_file_paths(data)
-
     missing = []
-    for path in paths:
-        if not os.path.isfile(path):
-            print(f'MISSING: {path}')
-            missing.append(path)
+    for enrollmentfiles in data.values():
+        for enrollmentfile in enrollmentfiles:
+            # Verify existance of enrollment
+            if not os.path.isfile(enrollmentfile):
+                missing.append(enrollmentfile)
+
+            # Verify existance of profile referenced in enrollment
+            enrollment = load_yaml(enrollmentfile)
+            if not os.path.isfile(enrollment['profile']):
+                missing.append(f'{enrollment['profile']} (referenced in {enrollmentfile})')
+
+    for path in missing:
+        print(f'MISSING: {path}')
 
     if missing:
         print(f'\n{len(missing)} files missing.')
-    return len(missing) == 0
+
+    return not missing


### PR DESCRIPTION
This PR:
* Modifies the format of `domains.yaml`. Instead it will use the certificate profile defined within the referenced enrollmentfile. The base filename for revocations are exactly the same as the enrollment file albeit in a different directory. Therefore specifying both in `domains.yaml` is superfluous. 
* Fixes an incorrect reference to a nonexistant profile in `enrollment/TRIALPKIoverheidG4RootEUTLGSigs2026.yaml`