### PR TITLE
Implement various enhancements

### DIFF
--- a/lib/cert.py
+++ b/lib/cert.py
@@ -244,6 +244,6 @@ def process(profile: dict, enrollment: dict, subject_keys: KeyPair, config: dict
     with open(filename, "wb") as f:
         f.write(cert.public_bytes(serialization.Encoding.DER))
 
-    log_issued_cert(cert)
+    log_issued_cert(issuer_keys, subject_keys)
 
     logger.info(f"Certificate issued and saved to {filename}")

--- a/lib/events.py
+++ b/lib/events.py
@@ -4,26 +4,39 @@ import os
 from cryptography import x509
 from cryptography.x509.extensions import AuthorityKeyIdentifier
 
+from lib.keypair import KeyPair
+
 if not os.path.isdir('ca'):
     os.mkdir('ca')
 
+LOG_FILENAME = os.path.join('ca', 'events.txt')
+
+def configure_logger(logger, log_filename=LOG_FILENAME):
+    file_handler = logging.FileHandler(filename=log_filename)
+    formatter = logging.Formatter('%(asctime)s;%(name)s;%(levelname)s;%(message)s')
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+
+
 eventlog = logging.getLogger('events')
-file_handler = logging.FileHandler(filename=os.path.join('ca', 'events.txt'))
-formatter = logging.Formatter('%(asctime)s;%(name)s;%(levelname)s;%(message)s')
-file_handler.setFormatter(formatter)
-eventlog.addHandler(file_handler)
+configure_logger(eventlog)
 
 
-def log(msg: str):
+def log(msg: str, eventlog=eventlog):
     eventlog.info(msg)
 
 
-def log_issued_cert(cert: x509.Certificate):
+def _log_issued_cert(issuer_dn: str, aki: str, serial_number: int, enrollment: str, eventlog=eventlog):
+    log(f"issued;{issuer_dn};{aki};{serial_number};{enrollment}", eventlog=eventlog)
+
+
+def log_issued_cert(issuer: KeyPair, subject: KeyPair, eventlog=eventlog):
+    cert = subject.certificate
     aki = cert.extensions.get_extension_for_class(AuthorityKeyIdentifier).value.key_identifier.hex()
-    log(f"issued;{aki};{cert.serial_number}")
+    _log_issued_cert(issuer.certificate.subject.rfc4514_string(), aki, cert.serial_number, subject.basename, eventlog=eventlog)
 
 
-def log_signed_crl(crl: x509.CertificateRevocationList):
+def log_signed_crl(crl: x509.CertificateRevocationList, eventlog=eventlog):
     aki = crl.extensions.get_extension_for_class(AuthorityKeyIdentifier).value.key_identifier.hex()
     crl_number = crl.extensions.get_extension_for_class(x509.CRLNumber).value.crl_number
-    log(f"crl;{aki};{crl_number}")
+    log(f"crl;{aki};{crl_number}", eventlog=eventlog)

--- a/lib/keypair.py
+++ b/lib/keypair.py
@@ -39,7 +39,13 @@ class KeyPair:
         return cls(pathlib.Path(filename).stem)
 
     def exists(self):
-        return os.path.isfile(self.privatekeyfile) or os.path.isfile(self.derfile)
+        return self.private_key_exists() or self.certificate_exists()
+
+    def private_key_exists(self):
+        return os.path.isfile(self.privatekeyfile)
+
+    def certificate_exists(self):
+        return os.path.isfile(self.derfile)
 
     def load(self, password=None):
         if self.public_key:
@@ -104,3 +110,6 @@ class KeyPair:
             c_loaded = " (loaded)"
 
         return f'KeyPair<Private Key={self.privatekeyfile}{p_loaded}, Certificate={self.derfile}{c_loaded}>'
+
+    def __eq__(self, value):
+        return self.basename == value

--- a/lib/san.py
+++ b/lib/san.py
@@ -1,11 +1,16 @@
-from cryptography import x509
-from cryptography.x509.oid import ObjectIdentifier
+from typing import Any
 
 from asn1crypto import core
-from asn1crypto.core import Sequence, UTF8String, IA5String, ObjectIdentifier as Asn1ObjectIdentifier
-from asn1crypto.x509 import GeneralNames, AnotherName, EmailAddress, DNSName
-
-from typing import Any
+from asn1crypto.core import IA5String, Sequence, UTF8String
+from asn1crypto.core import ObjectIdentifier as Asn1ObjectIdentifier
+from asn1crypto.x509 import (
+    AnotherName,
+    DNSName,
+    EmailAddress,
+    GeneralNames,
+)
+from cryptography import x509
+from cryptography.x509.oid import ObjectIdentifier
 
 
 def build_san_extension(subjectAltNames: list[dict[str,Any] | str], config) -> list[x509.GeneralName]:
@@ -29,7 +34,7 @@ def build_san_extension(subjectAltNames: list[dict[str,Any] | str], config) -> l
             # Existence of these attributes indicate an OtherName of type AnotherName containing a PermanentIdentifier
 
             class PermanentIdentifier(Sequence):
-                _fields = [
+                _fields = [  # noqa: RUF012
                     ('identifierValue', UTF8String),
                     ('assigner', Asn1ObjectIdentifier)
                 ]
@@ -75,24 +80,18 @@ class PermanentIdentifier(Sequence):
     """
     Define PermanentIdentifier structure according to RFC 4043
     """
-    _fields = [
+    _fields = [  # noqa: RUF012
         ("identifier_value", UTF8String, {"optional": True}),
         ("assigner", Asn1ObjectIdentifier, {"optional": True}),
     ]
 
 
-# Monkey patch to enable deep parsing of AnotherNames
-Asn1ObjectIdentifier._map = {
-    "1.3.6.1.5.5.7.8.3": 'permanent_identifier',
-    "1.3.6.1.4.1.311.20.2.3": 'MSUPN',  
-    "2.5.5.5": 'IA5',
-    "1.3.6.1.4.1.1466.115.121.1.26": 'IA5',
-}
 AnotherName._oid_pair = ('type_id', 'value')
 AnotherName._oid_specs = {
-    'permanent_identifier': PermanentIdentifier,
-    'MSUPN': core.UTF8String,
-    'IA5': core.IA5String
+    '1.3.6.1.5.5.7.8.3': PermanentIdentifier,
+    '1.3.6.1.4.1.311.20.2.3': core.UTF8String,
+    '2.5.5.5': core.IA5String,
+    '1.3.6.1.4.1.1466.115.121.1.26': core.IA5String
 }
 
 

--- a/sign-cert.py
+++ b/sign-cert.py
@@ -6,11 +6,15 @@ import sys
 
 import yaml
 from cryptography.hazmat.primitives import serialization
-from cryptography.x509 import  load_pem_x509_csr, SubjectAlternativeName, ExtensionNotFound
-from jschon import create_catalog, JSON, JSONSchema
-from lib.chain import write_full_chain
+from cryptography.x509 import (
+    ExtensionNotFound,
+    SubjectAlternativeName,
+    load_pem_x509_csr,
+)
+from jschon import JSON, JSONSchema, create_catalog
 
 from lib.cert import sign
+from lib.chain import write_full_chain
 from lib.csr import verify
 from lib.dn import generate_basename
 from lib.events import log_issued_cert
@@ -19,7 +23,6 @@ from lib.names import as_dict
 from lib.ra import validate
 from lib.san import read_generalnames
 from lib.util import load_yaml
-
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 logger = logging.getLogger("sign-cert")
@@ -68,15 +71,15 @@ if __name__ == "__main__":
 
     for csrfile in args.csrs:
 
-        logging.info(f"Processing {csrfile}")
+        logger.info(f"Processing {csrfile}")
 
-        # Rebuild enrollment data to we can verify it
+        # Rebuild enrollment data to we can verify
         with open(csrfile, "rb") as f:
             csr = load_pem_x509_csr(f.read())
 
         if not verify(csr):
             logger.fatal(f"{csrfile} signature is invalid, skipping ❌")
-            exit(1)
+            sys.exit(1)
 
         if not args.enrollment:
             # No enrollment file was provided, rebuild from CSR data
@@ -99,20 +102,20 @@ if __name__ == "__main__":
                 # Only write the enrollment file. Don't validate data against the certificate profile as this option
                 # may be used to correct an incorrect CSR
                 if os.path.isfile(args.write_enrollment):
-                    logger.fatal(f"Cannot write enrollment, file exists. Please remove it first")
-                    exit(1)
+                    logger.fatal(f"Cannot write enrollment, file {args.write_enrollment} exists. Please remove it first")
+                    sys.exit(1)
 
                 with open(args.write_enrollment, "w") as f:
                     yaml.dump(enrollment, f)
 
-                logging.info(f"Wrote enrollment to {args.write_enrollment}")
+                logger.info(f"Wrote enrollment to {args.write_enrollment}")
 
                 continue
         else:
             # Use provided enrollment file
             enrollment = load_yaml(args.enrollment)
 
-        # Validate
+        # Validate enrollment
         subject_profile = load_yaml(enrollment['profile'])
         validate(enrollment, subject_profile)
 
@@ -125,9 +128,9 @@ if __name__ == "__main__":
         issuer_keys = KeyPair(generate_basename(issuer_profile['subject']))
         try:
             issuer_keys.load(password=args.issuer_password)
-        except FileNotFoundError as e:
+        except FileNotFoundError:
             logger.fatal(f"Cannot find keys of {issuer_keys} for signing operation, please generate it first")
-            exit(1)
+            sys.exit(1)
 
         cert = sign(subject_profile, enrollment, issuer_profile, subject_keys, issuer_keys, config)
 
@@ -136,7 +139,7 @@ if __name__ == "__main__":
         with open(filename, "wb") as f:
             f.write(cert.public_bytes(serialization.Encoding.DER))
 
-        log_issued_cert(cert)
+        log_issued_cert(issuer_keys, subject_keys)
 
         logger.info(f"Certificate issued and saved to {filename}")
 


### PR DESCRIPTION
This PR:
* Updates the logging in `ca/events.txt` to be more descriptive in assessing which certificates which were issued (breaking change if you already rely in the formating and contents of this file
* Enable logging substitution (for unit testing)
* Bug fix: if the method `Name.build` was used from asn1crypto, it would fail transforming internal attribute names to OIDs and vice versa. 