### PR TITLE
Additional logging fields and implement lookup function

### DIFF
--- a/lib/events.py
+++ b/lib/events.py
@@ -1,3 +1,4 @@
+import csv
 import logging
 import os
 
@@ -11,6 +12,7 @@ if not os.path.isdir('ca'):
 
 LOG_FILENAME = os.path.join('ca', 'events.txt')
 
+
 def configure_logger(logger, log_filename=LOG_FILENAME):
     file_handler = logging.FileHandler(filename=log_filename)
     formatter = logging.Formatter('%(asctime)s;%(name)s;%(levelname)s;%(message)s')
@@ -22,21 +24,36 @@ eventlog = logging.getLogger('events')
 configure_logger(eventlog)
 
 
-def log(msg: str, eventlog=eventlog):
+def log(msg: str, eventlog=eventlog) -> None:
     eventlog.info(msg)
 
 
-def _log_issued_cert(issuer_dn: str, aki: str, serial_number: int, enrollment: str, eventlog=eventlog):
-    log(f"issued;{issuer_dn};{aki};{serial_number};{enrollment}", eventlog=eventlog)
+def _log_issued_cert(issuer_enrollment: str, issuer_dn: str, aki: str, cert_serial_number: int, enrollment: str, eventlog=eventlog) -> None:
+    log(f"issued;{issuer_enrollment};{issuer_dn};{aki};{cert_serial_number};{enrollment}", eventlog=eventlog)
 
 
-def log_issued_cert(issuer: KeyPair, subject: KeyPair, eventlog=eventlog):
+def log_issued_cert(issuer: KeyPair, subject: KeyPair, eventlog=eventlog) -> None:
     cert = subject.certificate
     aki = cert.extensions.get_extension_for_class(AuthorityKeyIdentifier).value.key_identifier.hex()
-    _log_issued_cert(issuer.certificate.subject.rfc4514_string(), aki, cert.serial_number, subject.basename, eventlog=eventlog)
+    _log_issued_cert(issuer.basename, issuer.certificate.subject.rfc4514_string(), aki, cert.serial_number, subject.basename, eventlog=eventlog)
 
 
-def log_signed_crl(crl: x509.CertificateRevocationList, eventlog=eventlog):
+def log_signed_crl(crl: x509.CertificateRevocationList, eventlog=eventlog) -> None:
     aki = crl.extensions.get_extension_for_class(AuthorityKeyIdentifier).value.key_identifier.hex()
     crl_number = crl.extensions.get_extension_for_class(x509.CRLNumber).value.crl_number
     log(f"crl;{aki};{crl_number}", eventlog=eventlog)
+
+
+def lookup(issuer_dn: str, serial_number: int, logfile=LOG_FILENAME) -> str:
+    """
+    Looks up the basename of a certificate by its issuer DN and serial number in the event log file.
+    """
+    with open(logfile, encoding="utf-8") as f:
+        for row in csv.reader(f, delimiter=";"):
+            if row[3] != "issued":
+                continue
+
+            if row[5] == issuer_dn and row[7] == str(serial_number):
+                return row[4],row[8]
+
+    raise ValueError("Certificate not found")

--- a/tests/events_test.py
+++ b/tests/events_test.py
@@ -1,9 +1,7 @@
 import logging
 import unittest
 
-from lib.ca import lookup
-
-from lib.events import _log_issued_cert, configure_logger
+from lib.events import _log_issued_cert, configure_logger, lookup
 
 
 class TestCA(unittest.TestCase):

--- a/tests/events_test.py
+++ b/tests/events_test.py
@@ -1,0 +1,44 @@
+import logging
+import unittest
+
+from lib.ca import lookup
+
+from lib.events import _log_issued_cert, configure_logger
+
+
+class TestCA(unittest.TestCase):
+
+    logfile = 'ca_test.txt'
+
+    def setUp(self):
+        logging.basicConfig(
+            level=logging.DEBUG,
+            force=True,
+        )
+        self.log = logging.getLogger('test')
+        configure_logger(self.log, log_filename=self.logfile)
+
+    def tearDown(self):
+        logging.shutdown()
+
+        # Clean up the test log file after each test
+        import os
+        if os.path.exists(self.logfile):
+            os.remove(self.logfile)
+
+    def test_lookup_found(self):
+        _log_issued_cert("my_ca", "2.5.4.97=NTRNL-99999990,CN=TRIAL My TSP - G4 PKIo Priv G-TLS SYS - 2026,O=TRIAL My TSP - not for Production use,C=NL", "SOMEAKI", 12345, "myenrollmentfile1", eventlog=self.log)
+        _log_issued_cert("my_ca", "2.5.4.97=NTRNL-99999990,CN=TRIAL My TSP - G4 PKIo Priv G-TLS SYS - 2026,O=TRIAL My TSP - not for Production use,C=NL", "SOMEAKI", 67890, "myenrollmentfile2", eventlog=self.log)
+        _log_issued_cert("my_ca", "2.5.4.97=NTRNL-99999990,CN=TRIAL My TSP - G4 PKIo Priv G-TLS SYS - 2026,O=TRIAL My TSP - not for Production use,C=NL", "SOMEAKI", 14725, "myenrollmentfile3", eventlog=self.log)
+        _log_issued_cert("my_ca", "2.5.4.97=NTRNL-99999990,CN=TRIAL My TSP - G4 PKIo Priv G-TLS SYS - 2026,O=TRIAL My TSP - not for Production use,C=NL", "SOMEAKI", 25836, "myenrollmentfile4", eventlog=self.log)
+
+        issuer,name = lookup("2.5.4.97=NTRNL-99999990,CN=TRIAL My TSP - G4 PKIo Priv G-TLS SYS - 2026,O=TRIAL My TSP - not for Production use,C=NL", 14725, self.logfile)
+
+        self.assertEqual(issuer, "my_ca")
+        self.assertEqual(name, "myenrollmentfile3")
+
+    def test_lookup_not_found(self):
+        _log_issued_cert("my_ca", "2.5.4.97=NTRNL-99999990,CN=TRIAL My TSP - G4 PKIo Priv G-TLS SYS - 2026,O=TRIAL My TSP - not for Production use,C=NL", "SOMEAKI", 12345, "myenrollmentfile1", eventlog=self.log)
+
+        with self.assertRaises(ValueError):
+            lookup("C=NL", 1, self.logfile)


### PR DESCRIPTION
This PR:
* Adds some additional fields to the logging, making lookup easier (required for future Proof of Possession attribute handling)
* Provides a lookup function to determine if a certificate was indeed issued by one of the created CAs. 