### PR TITLE
Let `create-ca.py` be nothing more than a wrapper

### DIFF
--- a/create-ca.py
+++ b/create-ca.py
@@ -1,19 +1,16 @@
 import logging
+import subprocess
 import sys
 from pathlib import Path
 
-from lib import cert, crl
 from lib.domains import verify
-from lib.keypair import KeyPair
-from lib.util import choose, load_config, load_yaml
+from lib.util import choose, load_yaml
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 logger = logging.getLogger("create-ca")
 
 
 def main():
-    config = load_config()
-
     options = load_yaml("domains.yaml")['domains']
     if not verify(options):
         sys.exit(1)
@@ -23,15 +20,15 @@ def main():
     enrollmentfiles = options[hierarchy]
     revocationfiles = [Path("revocations").joinpath(Path(enrollmentfile).name) for enrollmentfile in enrollmentfiles]
 
-    # Creating a hierarchy is simply creating the certificates and CRLs in sequence
-    for enrollmentfile, revocationfile in zip(enrollmentfiles, revocationfiles):
-        enrollment = load_yaml(enrollmentfile)
-        profile = load_yaml(enrollment['profile'])
-        subject_keys = KeyPair.for_filename(enrollmentfile)
-        cert.process(profile, enrollment, subject_keys, config)
-        crl.process(revocationfile, config, force=True)
+    gen_certs = ["python", "generate-cert.py"]
+    gen_certs.extend(enrollmentfiles)
+    subprocess.run(gen_certs, check=True) 
 
-    print('To automate this step, run next time:')
+    gen_crls = ["python", "generate-crl.py"]
+    gen_crls.extend(revocationfiles)
+    subprocess.run(gen_crls, check=True) 
+    
+    print('\nTo automate this step, run next time:')
     filenames = "\' \'".join(enrollmentfiles)
     print(f'python generate-cert.py \'{filenames}\'')
     filenames = "\' \'".join([str(f) for f in revocationfiles])


### PR DESCRIPTION
This PR:
* Simplifies the internal workings of `create-ca.py`. Rather than internally calling python functions, use a subshell to execute commands. 