### PR TITLE
Use a more simplistic event log; use one Config object

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,3 +4,4 @@ crlRenewalHours: 48
 pdsLocation:
   url: https://www.github.com/pkioverheid/g4-trial
   language: en
+logFilename: ca/events.txt

--- a/lib/cert.py
+++ b/lib/cert.py
@@ -9,7 +9,8 @@ from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.x509 import UnrecognizedExtension
 from cryptography.x509.oid import ObjectIdentifier
 
-from .events import log_issued_cert
+from .config import Config
+from .events import Eventlog
 from .keypair import KeyPair, get_hash_algo
 from .names import as_name
 from .qc_statements import build_qc_statements_extension
@@ -249,6 +250,7 @@ def process(profile: dict, enrollment: dict, subject_keys: KeyPair, config: dict
     with open(filename, "wb") as f:
         f.write(cert.public_bytes(serialization.Encoding.DER))
 
-    log_issued_cert(issuer_keys, subject_keys)
+    log = Eventlog(Config.from_yaml("config.yaml"))
+    log.log_issued_cert(issuer_keys, subject_keys)
 
     logger.info(f"Certificate issued and saved to {filename}")

--- a/lib/config.py
+++ b/lib/config.py
@@ -1,8 +1,77 @@
 import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+from jschon import JSON, JSONSchema, create_catalog
+
+from lib.util import output_errors
 
 BASEDIR = 'ca'
 
 # Ensure our output directories exist
-for dir in [BASEDIR, os.path.join(BASEDIR, 'private'), os.path.join(BASEDIR, 'certs')]:
+for dir in [BASEDIR, os.path.join(BASEDIR, 'private'), os.path.join(BASEDIR, 'certs'), os.path.join(BASEDIR, 'crls')]:
     if not os.path.isdir(dir):
         os.mkdir(dir)
+
+
+@dataclass(frozen=True)
+class PDSLocation:
+    url: str
+    language: str
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "PDSLocation":
+        return cls(
+            url=data["url"],
+            language=data["language"]
+        )
+
+    def as_dict(self) -> dict:
+        return {
+                'url': self.url,
+                'language': self.language
+            }
+    
+
+@dataclass(frozen=True)
+class Config:
+    log_filename: str = 'ca/events.txt'
+    ca_issuers_base_url: str = 'http://cert.pkioverheid.nl'
+    crl_distribution_points_base_url: str = 'http://crl.pkioverheid.nl'
+    crl_renewal_hours: int = 48
+    pds_location: PDSLocation = PDSLocation('https://www.github.com/pkioverheid/g4-trial', 'en')
+
+   
+    @classmethod
+    def from_yaml(cls, filename: str) -> "Config":
+        with Path(filename).open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+
+            create_catalog("2020-12")
+            schema = JSONSchema.loadf(os.path.join('schema', 'config.json'))
+
+            instance = JSON(data)
+            result = schema.evaluate(instance)
+            if not result.valid:
+                print(f"Configuration file {filename} is invalid: ")
+                output_errors(result.output("detailed")["errors"])
+                raise SyntaxError(f"Configuration file {filename} is invalid")
+
+        return cls(
+            log_filename=data["logFilename"],
+            ca_issuers_base_url=data["caIssuersBaseUrl"],
+            crl_distribution_points_base_url=data["cRLDistributionPointsBaseUrl"],
+            crl_renewal_hours=data["crlRenewalHours"],
+            pds_location=PDSLocation(data["pdsLocation"]["url"], data["pdsLocation"]["language"])
+        )
+
+    def as_dict(self) -> dict:
+        return {
+            'logFilename': self.log_filename,
+            'caIssuersBaseUrl': self.ca_issuers_base_url,
+            'cRLDistributionPointsBaseUrl': self.crl_distribution_points_base_url,
+            'crlRenewalHours': self.crl_renewal_hours,
+            'pdsLocation': self.pds_location.as_dict()
+        }
+

--- a/lib/crl.py
+++ b/lib/crl.py
@@ -9,7 +9,8 @@ from cryptography.x509 import ReasonFlags, load_der_x509_crl
 from cryptography.x509.extensions import BasicConstraints
 from jschon import create_catalog, JSON, JSONSchema
 
-from .events import log_signed_crl
+from .config import Config
+from .events import Eventlog
 from .keypair import KeyPair
 from .util import force_int, load_yaml, output_errors
 
@@ -134,6 +135,7 @@ def process(revocationfile, config, force=False, issuer_password=None):
     with open(filename, "wb") as f:
         f.write(crl.public_bytes(serialization.Encoding.DER))
 
-    log_signed_crl(crl)
+    log = Eventlog(Config.from_yaml("config.yaml"))
+    log.log_signed_crl(crl)
 
     logger.info(f"Signed CRL with number {current_crl_number+1} containing {len(profile['revocations'])} revocations and saved to {filename}")

--- a/lib/events.py
+++ b/lib/events.py
@@ -1,57 +1,54 @@
 import csv
-import logging
-import os
+import datetime
 
 from cryptography import x509
 from cryptography.x509.extensions import AuthorityKeyIdentifier
 
-from .config import BASEDIR
+from .config import Config
 from .keypair import KeyPair
 
-LOG_FILENAME = os.path.join(BASEDIR, 'events.txt')
+
+class Eventlog:
+
+    def __init__(self, config: Config):
+        self.config = config
+
+    def log(self, msg: str) -> None:
+        with open(self.config.log_filename, "a") as log:
+            str = '%(asctime)s;%(name)s;%(levelname)s;%(message)s\n' % { #noqa: UP031
+                'asctime': datetime.datetime.now(datetime.timezone.utc),
+                'name': 'events',
+                'levelname': 'INFO', 
+                'message': msg
+            }
+            log.write(str)
+            log.flush()
+
+    def _log_issued_cert(self, issuer_enrollment: str, issuer_dn: str, aki: str, cert_serial_number: int, enrollment: str) -> None:
+        self.log(f"issued;{issuer_enrollment};{issuer_dn};{aki};{cert_serial_number};{enrollment}")
 
 
-def configure_logger(logger, log_filename=LOG_FILENAME):
-    file_handler = logging.FileHandler(filename=log_filename)
-    formatter = logging.Formatter('%(asctime)s;%(name)s;%(levelname)s;%(message)s')
-    file_handler.setFormatter(formatter)
-    logger.addHandler(file_handler)
+    def log_issued_cert(self, issuer: KeyPair, subject: KeyPair) -> None:
+        cert = subject.certificate
+        aki = cert.extensions.get_extension_for_class(AuthorityKeyIdentifier).value.key_identifier.hex()
+        self._log_issued_cert(issuer.basename, issuer.certificate.subject.rfc4514_string(), aki, cert.serial_number, subject.basename)
 
 
-eventlog = logging.getLogger('events')
-configure_logger(eventlog)
+    def log_signed_crl(self, crl: x509.CertificateRevocationList) -> None:
+        aki = crl.extensions.get_extension_for_class(AuthorityKeyIdentifier).value.key_identifier.hex()
+        crl_number = crl.extensions.get_extension_for_class(x509.CRLNumber).value.crl_number
+        self.log(f"crl;{aki};{crl_number}")
 
 
-def log(msg: str, eventlog=eventlog) -> None:
-    eventlog.info(msg)
+    def lookup(self, issuer_dn: str, serial_number: int) -> str:
+        """
+        Looks up the basename of a certificate by its issuer DN and serial number in the event log file.
+        """
+        with open(self.config.log_filename, encoding="utf-8") as f:
+            for row in csv.reader(f, delimiter=";"):
+                if row[3] != "issued":
+                    continue
+                if row[5] == issuer_dn and row[7] == str(serial_number):
+                    return row[4],row[8]
 
-
-def _log_issued_cert(issuer_enrollment: str, issuer_dn: str, aki: str, cert_serial_number: int, enrollment: str, eventlog=eventlog) -> None:
-    log(f"issued;{issuer_enrollment};{issuer_dn};{aki};{cert_serial_number};{enrollment}", eventlog=eventlog)
-
-
-def log_issued_cert(issuer: KeyPair, subject: KeyPair, eventlog=eventlog) -> None:
-    cert = subject.certificate
-    aki = cert.extensions.get_extension_for_class(AuthorityKeyIdentifier).value.key_identifier.hex()
-    _log_issued_cert(issuer.basename, issuer.certificate.subject.rfc4514_string(), aki, cert.serial_number, subject.basename, eventlog=eventlog)
-
-
-def log_signed_crl(crl: x509.CertificateRevocationList, eventlog=eventlog) -> None:
-    aki = crl.extensions.get_extension_for_class(AuthorityKeyIdentifier).value.key_identifier.hex()
-    crl_number = crl.extensions.get_extension_for_class(x509.CRLNumber).value.crl_number
-    log(f"crl;{aki};{crl_number}", eventlog=eventlog)
-
-
-def lookup(issuer_dn: str, serial_number: int, logfile=LOG_FILENAME) -> str:
-    """
-    Looks up the basename of a certificate by its issuer DN and serial number in the event log file.
-    """
-    with open(logfile, encoding="utf-8") as f:
-        for row in csv.reader(f, delimiter=";"):
-            if row[3] != "issued":
-                continue
-
-            if row[5] == issuer_dn and row[7] == str(serial_number):
-                return row[4],row[8]
-
-    raise ValueError(f"Certificate with serial number {serial_number} issued by {issuer_dn} not found")
+        raise ValueError(f"Certificate with serial number {serial_number} issued by {issuer_dn} not found")

--- a/lib/keypair.py
+++ b/lib/keypair.py
@@ -57,7 +57,7 @@ class KeyPair:
     def certificate_exists(self) -> bool:
         return os.path.isfile(self.derfile) or os.path.isfile(self.pemfile)
 
-    def load(self, password=None):
+    def load(self, password=None) -> "KeyPair":
         if self.public_key:
             logger.debug("Public Key already loaded")
 
@@ -71,14 +71,14 @@ class KeyPair:
 
         return self
 
-    def _load_private_key(self, password: str | None = None):
+    def _load_private_key(self, password: str | None = None) -> "KeyPair":
         with open(self.privatekeyfile, "rb") as f:
             if password:
                 password = password.encode("utf-8")
             self.private_key = serialization.load_pem_private_key(f.read(), password=password)
         return self
 
-    def _load_certificate(self):
+    def _load_certificate(self) -> "KeyPair":
         # Load the certificate and extract the public key
         try:
             with open(self.derfile, "rb") as f:
@@ -90,7 +90,7 @@ class KeyPair:
         self.public_key = self.certificate.public_key()
         return self
 
-    def generate_private_key(self, profile:dict, password=None):
+    def generate_private_key(self, profile:dict, password=None) -> "KeyPair":
         publicKeyAlgorithm = profile['publicKeyAlgorithm']
         
         match publicKeyAlgorithm:
@@ -120,11 +120,17 @@ class KeyPair:
                 encryption_algorithm=encryption
             ))
 
-    def load_from_csr(self, csr: CertificateSigningRequest):
+        return self
+
+    def load_from_csr(self, csr: CertificateSigningRequest) -> "KeyPair":
         if self.private_key or self.public_key:
             raise ValueError('Some keys are already loaded, not overriding them from CSR.')
+
         self.public_key = csr.public_key()
+
         logger.info("Loaded public key from CSR")
+
+        return self
 
     def __str__(self):
         p_loaded = ""

--- a/lib/util.py
+++ b/lib/util.py
@@ -1,8 +1,6 @@
-import os
 import sys
 
 import yaml
-from jschon import JSON, JSONSchema, create_catalog
 
 
 def force_int(value):
@@ -64,40 +62,3 @@ def choose(prompt, options):
             return options[int(choice) - 1]
         else:
             print("Invalid choice. Try again.")
-
-
-def load_config():
-    filename = "config.yaml"
-
-    try:
-        config = load_yaml(filename) or {}
-    except FileNotFoundError:
-        config = {}
-
-    defaults = {
-        "caIssuersBaseUrl": "http://cert.pkioverheid.nl",
-        "cRLDistributionPointsBaseUrl": "http://crl.pkioverheid.nl",
-        "crlRenewalHours": 48,
-        "pdsLocation": {
-            "url": "https://www.github.com/pkioverheid/g4-trial",
-            "language": "en",
-        },
-    }
-    defaults.update(config)
-    config = defaults
-
-    create_catalog("2020-12")
-    schema = JSONSchema.loadf(os.path.join('schema', 'config.json'))
-
-    instance = JSON(config)
-    result = schema.evaluate(instance)
-    if not result.valid:
-        print(f"Configuration file {filename} is invalid: ")
-        output_errors(result.output("detailed")["errors"])
-        raise SyntaxError(f"Configuration file {filename} is invalid")
-
-    # Only write file if validation passed, to avoid overwriting with invalid data
-    with open(filename, "w") as f:
-        yaml.safe_dump(config, f, sort_keys=False)
-
-    return config

--- a/schema/config.json
+++ b/schema/config.json
@@ -2,6 +2,10 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "properties": {
+    "logFilename": {
+      "type": "string",
+      "description": "Filename of the CA log. This file will contain CA events, such as certificate issuance."
+    },
     "caIssuersBaseUrl": {
       "type": "string",
       "format": "uri",
@@ -32,6 +36,6 @@
       "additionalProperties": false
     }
   },
-  "required": ["caIssuersBaseUrl", "cRLDistributionPointsBaseUrl", "crlRenewalHours", "pdsLocation"],
+  "required": ["logFilename", "caIssuersBaseUrl", "cRLDistributionPointsBaseUrl", "crlRenewalHours", "pdsLocation"],
   "additionalProperties": false
 }

--- a/sign-cert.py
+++ b/sign-cert.py
@@ -16,8 +16,9 @@ from jschon import JSON, JSONSchema, create_catalog
 
 from lib.cert import sign
 from lib.chain import write_full_chain
+from lib.config import Config
 from lib.csr import verify
-from lib.events import log_issued_cert
+from lib.events import Eventlog
 from lib.keypair import KeyPair
 from lib.names import as_dict, generate_basename
 from lib.ra import validate
@@ -144,7 +145,8 @@ if __name__ == "__main__":
         with open(filename, "wb") as f:
             f.write(cert.public_bytes(serialization.Encoding.DER))
 
-        log_issued_cert(issuer_keys, subject_keys)
+        log = Eventlog(Config.from_yaml("config.yaml"))
+        log.log_issued_cert(issuer_keys, subject_keys)
 
         logger.info(f"Certificate issued and saved to {filename}")
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,0 +1,201 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from lib.config import Config, PDSLocation
+
+
+class TestPDSLocation(unittest.TestCase):
+
+    def test_create(self):
+        pds = PDSLocation(
+            url="https://example.com",
+            language="en",
+        )
+
+        self.assertEqual(pds.url, "https://example.com")
+        self.assertEqual(pds.language, "en")
+
+    def test_from_dict(self):
+        data = {
+            "url": "https://example.com",
+            "language": "nl",
+        }
+
+        pds = PDSLocation.from_dict(data)
+
+        self.assertEqual(
+            pds,
+            PDSLocation(
+                url="https://example.com",
+                language="nl",
+            ),
+        )
+
+    def test_as_dict(self):
+        pds = PDSLocation(
+            url="https://example.com",
+            language="en",
+        )
+
+        self.assertEqual(
+            pds.as_dict(),
+            {
+                "url": "https://example.com",
+                "language": "en",
+            },
+        )
+
+    def test_is_frozen(self):
+        pds = PDSLocation(
+            url="https://example.com",
+            language="en",
+        )
+
+        with self.assertRaises(AttributeError):
+            pds.url = "https://other.example.com"
+
+
+class TestConfig(unittest.TestCase):
+
+    def test_default_values(self):
+        config = Config()
+
+        self.assertEqual(config.log_filename, "ca/events.txt")
+        self.assertEqual(
+            config.ca_issuers_base_url,
+            "http://cert.pkioverheid.nl",
+        )
+        self.assertEqual(
+            config.crl_distribution_points_base_url,
+            "http://crl.pkioverheid.nl",
+        )
+        self.assertEqual(config.crl_renewal_hours, 48)
+        self.assertEqual(
+            config.pds_location,
+            PDSLocation(
+                url="https://www.github.com/pkioverheid/g4-trial",
+                language="en",
+            ),
+        )
+
+    def test_as_dict(self):
+        config = Config(
+            log_filename="test-ca/events.txt",
+            ca_issuers_base_url="https://cert.example.com",
+            crl_distribution_points_base_url="https://crl.example.com",
+            crl_renewal_hours=24,
+            pds_location=PDSLocation(
+                url="https://example.com/pds",
+                language="nl",
+            ),
+        )
+
+        self.assertEqual(
+            config.as_dict(),
+            {
+                "logFilename": "test-ca/events.txt",
+                "caIssuersBaseUrl": "https://cert.example.com",
+                "cRLDistributionPointsBaseUrl": "https://crl.example.com",
+                "crlRenewalHours": 24,
+                "pdsLocation": {
+                    "url": "https://example.com/pds",
+                    "language": "nl",
+                },
+            },
+        )
+
+    def test_from_yaml(self):
+        yaml_data = {
+            "logFilename": "test-ca/events.txt",
+            "caIssuersBaseUrl": "https://cert.example.com",
+            "cRLDistributionPointsBaseUrl": "https://crl.example.com",
+            "crlRenewalHours": 24,
+            "pdsLocation": {
+                "url": "https://example.com/pds",
+                "language": "nl",
+            },
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_dir = Path(temp_dir)
+            yaml_file = temp_dir / "config.yaml"
+
+            yaml_file.write_text(
+                yaml.safe_dump(yaml_data),
+                encoding="utf-8",
+            )
+
+            config = Config.from_yaml(str(yaml_file))
+
+            self.assertEqual(
+                config.log_filename,
+                "test-ca/events.txt",
+            )
+            self.assertEqual(
+                config.ca_issuers_base_url,
+                "https://cert.example.com",
+            )
+            self.assertEqual(
+                config.crl_distribution_points_base_url,
+                "https://crl.example.com",
+            )
+            self.assertEqual(config.crl_renewal_hours, 24)
+            self.assertEqual(
+                config.pds_location,
+                PDSLocation(
+                    url="https://example.com/pds",
+                    language="nl",
+                ),
+            )
+
+    def test_yaml_round_trip(self):
+        original = Config(
+            log_filename="test-ca/events.txt",
+            ca_issuers_base_url="https://cert.example.com",
+            crl_distribution_points_base_url="https://crl.example.com",
+            crl_renewal_hours=24,
+            pds_location=PDSLocation(
+                url="https://example.com/pds",
+                language="nl",
+            ),
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_dir = Path(temp_dir)
+            yaml_file = temp_dir / "config.yaml"
+
+            yaml_file.write_text(
+                yaml.safe_dump(original.as_dict()),
+                encoding="utf-8",
+            )
+
+            # from_yaml() invokes init()
+            loaded_data = yaml.safe_load(yaml_file.read_text())
+            yaml_file.write_text(
+                yaml.safe_dump(loaded_data),
+                encoding="utf-8",
+            )
+
+            loaded = Config.from_yaml(str(yaml_file))
+
+            self.assertEqual(loaded.log_filename, original.log_filename)
+            self.assertEqual(
+                loaded.ca_issuers_base_url,
+                original.ca_issuers_base_url,
+            )
+            self.assertEqual(
+                loaded.crl_distribution_points_base_url,
+                original.crl_distribution_points_base_url,
+            )
+            self.assertEqual(
+                loaded.crl_renewal_hours,
+                original.crl_renewal_hours,
+            )
+            self.assertEqual(
+                loaded.pds_location,
+                original.pds_location,
+            )
+

--- a/tests/events_test.py
+++ b/tests/events_test.py
@@ -1,42 +1,35 @@
-import logging
+import os
 import unittest
 
-from lib.events import _log_issued_cert, configure_logger, lookup
+from lib.config import Config
+from lib.events import Eventlog
+
+config = Config(log_filename="unittest.log")
 
 
-class TestCA(unittest.TestCase):
-
-    logfile = 'ca_test.txt'
-
-    def setUp(self):
-        logging.basicConfig(
-            level=logging.DEBUG,
-            force=True,
-        )
-        self.log = logging.getLogger('test')
-        configure_logger(self.log, log_filename=self.logfile)
+class TestEventlog(unittest.TestCase):
 
     def tearDown(self):
-        logging.shutdown()
-
-        # Clean up the test log file after each test
-        import os
-        if os.path.exists(self.logfile):
-            os.remove(self.logfile)
+        if os.path.isfile("unittest.log"):
+            os.remove("unittest.log")
+        return super().tearDown()
 
     def test_lookup_found(self):
-        _log_issued_cert("my_ca", "2.5.4.97=NTRNL-99999990,CN=TRIAL My TSP - G4 PKIo Priv G-TLS SYS - 2026,O=TRIAL My TSP - not for Production use,C=NL", "SOMEAKI", 12345, "myenrollmentfile1", eventlog=self.log)
-        _log_issued_cert("my_ca", "2.5.4.97=NTRNL-99999990,CN=TRIAL My TSP - G4 PKIo Priv G-TLS SYS - 2026,O=TRIAL My TSP - not for Production use,C=NL", "SOMEAKI", 67890, "myenrollmentfile2", eventlog=self.log)
-        _log_issued_cert("my_ca", "2.5.4.97=NTRNL-99999990,CN=TRIAL My TSP - G4 PKIo Priv G-TLS SYS - 2026,O=TRIAL My TSP - not for Production use,C=NL", "SOMEAKI", 14725, "myenrollmentfile3", eventlog=self.log)
-        _log_issued_cert("my_ca", "2.5.4.97=NTRNL-99999990,CN=TRIAL My TSP - G4 PKIo Priv G-TLS SYS - 2026,O=TRIAL My TSP - not for Production use,C=NL", "SOMEAKI", 25836, "myenrollmentfile4", eventlog=self.log)
+        log = Eventlog(config)
 
-        issuer,name = lookup("2.5.4.97=NTRNL-99999990,CN=TRIAL My TSP - G4 PKIo Priv G-TLS SYS - 2026,O=TRIAL My TSP - not for Production use,C=NL", 14725, self.logfile)
+        log._log_issued_cert("my_ca", "2.5.4.97=NTRNL-99999990,CN=TRIAL My TSP - G4 PKIo Priv G-TLS SYS - 2026,O=TRIAL My TSP - not for Production use,C=NL", "SOMEAKI", 12345, "myenrollmentfile1")
+        log._log_issued_cert("my_ca", "2.5.4.97=NTRNL-99999990,CN=TRIAL My TSP - G4 PKIo Priv G-TLS SYS - 2026,O=TRIAL My TSP - not for Production use,C=NL", "SOMEAKI", 67890, "myenrollmentfile2")
+        log._log_issued_cert("my_ca", "2.5.4.97=NTRNL-99999990,CN=TRIAL My TSP - G4 PKIo Priv G-TLS SYS - 2026,O=TRIAL My TSP - not for Production use,C=NL", "SOMEAKI", 14725, "myenrollmentfile3")
+        log._log_issued_cert("my_ca", "2.5.4.97=NTRNL-99999990,CN=TRIAL My TSP - G4 PKIo Priv G-TLS SYS - 2026,O=TRIAL My TSP - not for Production use,C=NL", "SOMEAKI", 25836, "myenrollmentfile4")
+
+        issuer,name = log.lookup("2.5.4.97=NTRNL-99999990,CN=TRIAL My TSP - G4 PKIo Priv G-TLS SYS - 2026,O=TRIAL My TSP - not for Production use,C=NL", 14725)
 
         self.assertEqual(issuer, "my_ca")
         self.assertEqual(name, "myenrollmentfile3")
 
     def test_lookup_not_found(self):
-        _log_issued_cert("my_ca", "2.5.4.97=NTRNL-99999990,CN=TRIAL My TSP - G4 PKIo Priv G-TLS SYS - 2026,O=TRIAL My TSP - not for Production use,C=NL", "SOMEAKI", 12345, "myenrollmentfile1", eventlog=self.log)
+        log = Eventlog(config)
+        log._log_issued_cert("my_ca", "2.5.4.97=NTRNL-99999990,CN=TRIAL My TSP - G4 PKIo Priv G-TLS SYS - 2026,O=TRIAL My TSP - not for Production use,C=NL", "SOMEAKI", 12345, "myenrollmentfile1")
 
         with self.assertRaises(ValueError):
-            lookup("C=NL", 1, self.logfile)
+            log.lookup("C=NL", 1)


### PR DESCRIPTION
This PR:
* Replaces the event log mechanism with a more simplistic variant. It also uses a class now;
* Allow a configuration parameter where the CA event log is written (for example for unittesting)
* Use a proper configuration object rather than a `dict`