### PR TITLE
Refactor date functions into a separate file

### DIFF
--- a/lib/cert.py
+++ b/lib/cert.py
@@ -1,8 +1,5 @@
 import logging
 import os
-import re
-from datetime import datetime, timedelta, timezone
-from typing import Union
 
 from cryptography import x509
 from cryptography.hazmat.primitives import serialization
@@ -18,6 +15,7 @@ from .qc_statements import build_qc_statements_extension
 from .ra import validate
 from .san import build_san_extension
 from .util import force_int, keys_exist, load_yaml
+from . import dates
 
 logger = logging.getLogger(__name__)
 
@@ -133,46 +131,6 @@ def handle_extensions(builder, ext, enrollment, subject_keys, ca_keys, config):
 
     return builder
 
-
-def _parse_date_str(input: Union[str | datetime]) -> datetime:
-    if isinstance(input, datetime):
-        # Absolute date in the correct type
-        return input
-    elif input == 'now':
-        return datetime.now(timezone.utc)
-
-    # assume date time format as string: parse
-    d = datetime.fromisoformat(input)
-
-    # If no timezone was included, assume UTC
-    if d.tzinfo is None or d.tzinfo.utcoffset(d) is None:
-        return d.replace(tzinfo=timezone.utc)
-
-    return d
-
-
-def _parse_not_after(input: Union[str | datetime], not_before: datetime, issuer_not_valid_after: Union[datetime | None]) -> datetime:
-    if isinstance(input, datetime):
-        # Absolute date
-        return input
-    
-    match = re.match("^issuer([0-9-+]+)d$", input)
-    if match:
-        if not issuer_not_valid_after:
-            raise ValueError(f'Certificate notAfter date depends on issuer, but has not been defined')
-        
-        # Is a period relative to the issuer's notAfter. NOTE: last second is inclusive, therefore substract one second
-        return issuer_not_valid_after + timedelta(days=int(match.group(1)), seconds=-1)
-    
-    match = re.match("^([0-9]+)d$", input)
-    if match:
-        # Relative date into the future
-        return not_before + timedelta(days=int(match.group(1)), seconds=-1)
-    
-    # Assume date time formated as string
-    return _parse_date_str(input)
-
-
 def sign(profile:dict, enrollment:dict, issuer_enrollment:dict, subject_keys:KeyPair, issuer_keys:KeyPair, config:Config) -> x509.Certificate:
 
     issuer_name = issuer_keys.certificate.subject if issuer_keys.certificate is not None else as_name(issuer_enrollment['subject'])
@@ -188,8 +146,8 @@ def sign(profile:dict, enrollment:dict, issuer_enrollment:dict, subject_keys:Key
         profile['extensions']['cRLDistributionPoints']['value'] = [value % replacements for value in profile['extensions']['cRLDistributionPoints']['value']]
 
     # Validity
-    not_before = _parse_date_str(profile['validity']['notBefore'])
-    not_after = _parse_not_after(profile['validity']['notAfter'], not_before, issuer_keys.certificate.not_valid_after_utc if issuer_keys.certificate_exists() else None)
+    not_before = dates.parse_date_str(profile['validity']['notBefore'])
+    not_after = dates.parse_not_after(profile['validity']['notAfter'], not_before, issuer_keys.certificate.not_valid_after_utc if issuer_keys.certificate_exists() else None)
 
     # Generate a random Serial number (20 octets)
     serial_number = int.from_bytes(os.urandom(20), "big") >> 1

--- a/lib/dates.py
+++ b/lib/dates.py
@@ -1,0 +1,47 @@
+import re
+from datetime import datetime, timedelta, timezone
+
+
+def parse_date_str(input: str | datetime) -> datetime:
+    if isinstance(input, datetime):
+        # Absolute date in the correct type
+        return input
+    elif input == "now":
+        return datetime.now(timezone.utc)
+
+    # assume date time format as string: parse
+    d = datetime.fromisoformat(input)
+
+    # If no timezone was included, assume UTC
+    if d.tzinfo is None or d.tzinfo.utcoffset(d) is None:
+        return d.replace(tzinfo=timezone.utc)
+
+    return d
+
+
+def parse_not_after(
+    input: str | datetime,
+    not_before: datetime,
+    issuer_not_valid_after: datetime | None,
+) -> datetime:
+    if isinstance(input, datetime):
+        # Absolute date
+        return input
+
+    match = re.match("^issuer([0-9-+]+)d$", input)
+    if match:
+        if not issuer_not_valid_after:
+            raise ValueError(
+                "Certificate notAfter date depends on issuer, but has not been defined"
+            )
+
+        # Is a period relative to the issuer's notAfter. NOTE: last second is inclusive, therefore substract one second
+        return issuer_not_valid_after + timedelta(days=int(match.group(1)), seconds=-1)
+
+    match = re.match("^([0-9]+)d$", input)
+    if match:
+        # Relative date into the future
+        return not_before + timedelta(days=int(match.group(1)), seconds=-1)
+
+    # Assume date time formated as string
+    return parse_date_str(input)

--- a/tests/cert_test.py
+++ b/tests/cert_test.py
@@ -1,5 +1,4 @@
 import unittest
-from datetime import datetime, timedelta, timezone
 
 import yaml
 from cryptography.x509 import (
@@ -22,7 +21,7 @@ from cryptography.x509 import (
     UniformResourceIdentifier,
 )
 
-from lib.cert import _parse_date_str, _parse_not_after, sign
+from lib.cert import sign
 from lib.config import Config
 from lib.keypair import KeyPair
 
@@ -142,133 +141,3 @@ class TestCert(unittest.TestCase):
             ),
         )
 
-
-class TestParseDateStr(unittest.TestCase):
-
-    def test_datetime_input(self):
-        value = datetime(2026, 8, 12, 10, 30, tzinfo=timezone.utc)
-        result = _parse_date_str(value)
-        self.assertIs(result, value)
-
-    def test_now(self):
-        before = datetime.now(timezone.utc)
-
-        result = _parse_date_str("now")
-
-        after = datetime.now(timezone.utc)
-
-        self.assertIsInstance(result, datetime)
-        self.assertGreaterEqual(result, before)
-        self.assertLessEqual(result, after)
-
-    def test_iso_datetime_string(self):
-        value = "2026-08-12T10:30:00+00:00"
-
-        result = _parse_date_str(value)
-
-        self.assertEqual(
-            result,
-            datetime(2026, 8, 12, 10, 30, tzinfo=timezone.utc),
-        )
-
-    def test_iso_datetime_string_without_timezone(self):
-        value = "2026-08-12T10:30:00"
-
-        result = _parse_date_str(value)
-
-        self.assertEqual(
-            result,
-            datetime(2026, 8, 12, 10, 30, tzinfo=timezone.utc),
-        )
-
-    def test_invalid_date_string(self):
-        with self.assertRaises(ValueError):
-            _parse_date_str("not-a-date")
-
-
-class TestParseNotAfter(unittest.TestCase):
-
-    def setUp(self):
-        self.not_before = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
-        self.issuer_not_after = datetime(
-            2027, 1, 1, 12, 0, tzinfo=timezone.utc
-        )
-
-    def test_datetime_input(self):
-        value = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
-
-        result = _parse_not_after(
-            value,
-            self.not_before,
-            self.issuer_not_after,
-        )
-
-        self.assertIs(result, value)
-
-    def test_issuer_relative_days(self):
-        result = _parse_not_after(
-            "issuer10d",
-            self.not_before,
-            self.issuer_not_after,
-        )
-
-        expected = (
-            self.issuer_not_after
-            + timedelta(days=10, seconds=-1)
-        )
-
-        self.assertEqual(result, expected)
-
-    def test_issuer_relative_negative_days(self):
-        result = _parse_not_after(
-            "issuer-10d",
-            self.not_before,
-            self.issuer_not_after,
-        )
-
-        expected = (
-            self.issuer_not_after
-            + timedelta(days=-10, seconds=-1)
-        )
-
-        self.assertEqual(result, expected)
-
-    def test_relative_zero_days(self):
-        result = _parse_not_after(
-            "0d",
-            self.not_before,
-            self.issuer_not_after,
-        )
-
-        expected = self.not_before - timedelta(seconds=1)
-
-        self.assertEqual(result, expected)
-
-    def test_iso_datetime_string(self):
-        value = "2026-06-01T12:00:00+00:00"
-
-        result = _parse_not_after(
-            value,
-            self.not_before,
-            self.issuer_not_after,
-        )
-
-        expected = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
-
-        self.assertEqual(result, expected)
-
-    def test_invalid_dependency(self):
-        with self.assertRaises(ValueError):
-            _parse_not_after(
-                "issuer-1d",
-                self.not_before,
-                None,
-            )
-
-    def test_invalid_string(self):
-        with self.assertRaises(ValueError):
-            _parse_not_after(
-                "not-a-date",
-                self.not_before,
-                self.issuer_not_after,
-            )

--- a/tests/dates_test.py
+++ b/tests/dates_test.py
@@ -1,0 +1,127 @@
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from lib.dates import parse_date_str, parse_not_after
+
+
+class TestParseDateStr(unittest.TestCase):
+
+    def test_datetime_input(self):
+        value = datetime(2026, 8, 12, 10, 30, tzinfo=timezone.utc)
+        result = parse_date_str(value)
+        self.assertIs(result, value)
+
+    def test_now(self):
+        before = datetime.now(timezone.utc)
+
+        result = parse_date_str("now")
+
+        after = datetime.now(timezone.utc)
+
+        self.assertIsInstance(result, datetime)
+        self.assertGreaterEqual(result, before)
+        self.assertLessEqual(result, after)
+
+    def test_iso_datetime_string(self):
+        value = "2026-08-12T10:30:00+00:00"
+
+        result = parse_date_str(value)
+
+        self.assertEqual(
+            result,
+            datetime(2026, 8, 12, 10, 30, tzinfo=timezone.utc),
+        )
+
+    def test_iso_datetime_string_without_timezone(self):
+        value = "2026-08-12T10:30:00"
+
+        result = parse_date_str(value)
+
+        self.assertEqual(
+            result,
+            datetime(2026, 8, 12, 10, 30, tzinfo=timezone.utc),
+        )
+
+    def test_invalid_date_string(self):
+        with self.assertRaises(ValueError):
+            parse_date_str("not-a-date")
+
+
+class TestParseNotAfter(unittest.TestCase):
+
+    def setUp(self):
+        self.not_before = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+        self.issuer_not_after = datetime(2027, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+    def test_datetime_input(self):
+        value = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+
+        result = parse_not_after(
+            value,
+            self.not_before,
+            self.issuer_not_after,
+        )
+
+        self.assertIs(result, value)
+
+    def test_issuer_relative_days(self):
+        result = parse_not_after(
+            "issuer10d",
+            self.not_before,
+            self.issuer_not_after,
+        )
+
+        expected = self.issuer_not_after + timedelta(days=10, seconds=-1)
+
+        self.assertEqual(result, expected)
+
+    def test_issuer_relative_negative_days(self):
+        result = parse_not_after(
+            "issuer-10d",
+            self.not_before,
+            self.issuer_not_after,
+        )
+
+        expected = self.issuer_not_after + timedelta(days=-10, seconds=-1)
+
+        self.assertEqual(result, expected)
+
+    def test_relative_zero_days(self):
+        result = parse_not_after(
+            "0d",
+            self.not_before,
+            self.issuer_not_after,
+        )
+
+        expected = self.not_before - timedelta(seconds=1)
+
+        self.assertEqual(result, expected)
+
+    def test_iso_datetime_string(self):
+        value = "2026-06-01T12:00:00+00:00"
+
+        result = parse_not_after(
+            value,
+            self.not_before,
+            self.issuer_not_after,
+        )
+
+        expected = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+
+        self.assertEqual(result, expected)
+
+    def test_invalid_dependency(self):
+        with self.assertRaises(ValueError):
+            parse_not_after(
+                "issuer-1d",
+                self.not_before,
+                None,
+            )
+
+    def test_invalid_string(self):
+        with self.assertRaises(ValueError):
+            parse_not_after(
+                "not-a-date",
+                self.not_before,
+                self.issuer_not_after,
+            )


### PR DESCRIPTION
This PR:
* Moves the date parsing functions from `cert.py` to its own `dates.py`. Update unittests accordingly. 