### PR TITLE
Use CSR verify function from cryptography library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /ca/
 __pycache__
 /*.csr
+.coverage
+__test

--- a/lib/csr.py
+++ b/lib/csr.py
@@ -48,24 +48,13 @@ def create_csr(profile: dict, enrollment: dict, subject_keys: KeyPair, password=
                         ))
 
 
-def verify(csr: CertificateSigningRequest) -> bool:
-    pub = csr.public_key()
-    sig = csr.signature
-    data = csr.tbs_certrequest_bytes
-    alg = csr.signature_hash_algorithm
-
-    try:
-        if isinstance(pub, rsa.RSAPublicKey):
-            pub.verify(sig, data, csr.signature_algorithm_parameters, alg)
-        elif isinstance(pub, ec.EllipticCurvePublicKey):
-            pub.verify(sig, data, ec.ECDSA(alg))
-        elif isinstance(pub, (ed25519.Ed25519PublicKey, ed448.Ed448PublicKey)):
-            pub.verify(sig, data)
-        else:
-            raise UnsupportedAlgorithm(f"Unsupported signature algorithm {type(pub)}")
-        return True
-    except InvalidSignature:
-        return False
+def verify(csr: CertificateSigningRequest) -> None:
+    """
+    Verifies whether the CSR is acceptable to us. Raises an
+    exception if it fails. 
+    """
+    if not csr.is_signature_valid:
+        raise InvalidSignature()
 
 
 def process(profile: dict, enrollment: dict, keypair: KeyPair, subject_password=None) -> None:

--- a/sign-cert.py
+++ b/sign-cert.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
         with open(csrfile, "rb") as f:
             csr = load_pem_x509_csr(f.read())
 
-        # Verify the CSR
+        # Verify the CSR cryptografically
         try:
             verify(csr)
         except InvalidSignature:
@@ -88,13 +88,13 @@ if __name__ == "__main__":
             sys.exit(1)
 
         if not args.enrollment:
-            # No enrollment file was provided, rebuild from CSR data
+            # No enrollment file was provided, rebuild from CSR data to allow verification one set of code
             enrollment = {
                 'profile': 'tbd',
                 'subject': as_dict(csr.subject)
             }
 
-            # Rebuild internal representation of the included SAN to allow validation
+            # If present, rebuild SANs
             try:
                 ext = csr.extensions.get_extension_for_class(SubjectAlternativeName)
                 enrollment['subjectAltNames'] = read_generalnames(ext.value.public_bytes())
@@ -102,6 +102,7 @@ if __name__ == "__main__":
             except ExtensionNotFound:
                 pass
 
+            # Use or find a matching certificate profile
             enrollment['profile'] = args.profile or find_profile(enrollment)
 
             if args.write_enrollment:


### PR DESCRIPTION
This PR:
* Removes or own implementation to verify a CSR cryptographically and leverages existing code from the cryptography library. 
* Fixes that `verify` does not return a `bool`, but raises an exception if something fails. 

